### PR TITLE
Make the engine play: PeSTO evaluation, MCTS search, full UCI support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,8 +42,10 @@ fn generate_zobrist_keys() {
 // Piece indices match the order of PieceKind, the planes match the order of
 // Piece.
 
-const MIDDLEGAME_VALUE: [i32; 6] = [0, 1025, 477, 365, 337, 82];
-const ENDGAME_VALUE: [i32; 6] = [0, 936, 512, 297, 281, 94];
+// Piece base values in `PieceKind` order: Pawn, Knight, Bishop, Rook, Queen,
+// King.
+const MIDDLEGAME_VALUE: [i32; 6] = [82, 337, 365, 477, 1025, 0];
+const ENDGAME_VALUE: [i32; 6] = [94, 281, 297, 512, 936, 0];
 
 #[rustfmt::skip]
 const MIDDLEGAME_PAWN_TABLE: [i32; 64] = [
@@ -193,9 +195,13 @@ fn populate_piece_values(
     phase_values: &[i32; 6],
     output: &mut [[i32; 64]; 12],
 ) {
+    // The source tables are written from White's perspective with rank 8 first
+    // (the way boards are usually printed), while the board representation is
+    // Little-Endian Rank-File (A1 = 0). Hence, White planes mirror the table
+    // vertically and Black planes read it as is.
     for square in 0..64 {
-        output[piece_index][square] = phase_values[piece_index] + piece_values[square];
-        output[6 + piece_index][square] = phase_values[piece_index] + piece_values[flip(square)];
+        output[piece_index][square] = phase_values[piece_index] + piece_values[flip(square)];
+        output[6 + piece_index][square] = phase_values[piece_index] + piece_values[square];
     }
 }
 
@@ -203,13 +209,16 @@ fn generate_pesto_tables() {
     let mut middlegame_table = [[0; 64]; 12];
     let mut endgame_table = [[0; 64]; 12];
 
+    // The plane order matches `Piece::plane()`: planes 0-5 are White pieces in
+    // `PieceKind` order (Pawn, Knight, Bishop, Rook, Queen, King), planes 6-11
+    // are Black pieces in the same order.
     for (piece_index, (middlegame_piece_table, endgame_piece_table)) in [
-        (&MIDDLEGAME_KING_TABLE, &ENDGAME_KING_TABLE),
-        (&MIDDLEGAME_QUEEN_TABLE, &ENDGAME_QUEEN_TABLE),
-        (&MIDDLEGAME_ROOK_TABLE, &ENDGAME_ROOK_TABLE),
-        (&MIDDLEGAME_BISHOP_TABLE, &ENDGAME_BISHOP_TABLE),
-        (&MIDDLEGAME_KNIGHT_TABLE, &ENDGAME_KNIGHT_TABLE),
         (&MIDDLEGAME_PAWN_TABLE, &ENDGAME_PAWN_TABLE),
+        (&MIDDLEGAME_KNIGHT_TABLE, &ENDGAME_KNIGHT_TABLE),
+        (&MIDDLEGAME_BISHOP_TABLE, &ENDGAME_BISHOP_TABLE),
+        (&MIDDLEGAME_ROOK_TABLE, &ENDGAME_ROOK_TABLE),
+        (&MIDDLEGAME_QUEEN_TABLE, &ENDGAME_QUEEN_TABLE),
+        (&MIDDLEGAME_KING_TABLE, &ENDGAME_KING_TABLE),
     ]
     .iter()
     .enumerate()

--- a/src/bin/pabi.rs
+++ b/src/bin/pabi.rs
@@ -14,8 +14,8 @@ fn main() -> anyhow::Result<()> {
     pabi::print_engine_info();
     pabi::print_binary_info();
 
-    let mut input = std::io::stdin().lock();
-    let mut output = std::io::stdout().lock();
-    let mut engine = pabi::engine::Engine::new(&mut input, &mut output);
+    let input = std::io::stdin().lock();
+    let output = std::io::stdout();
+    let mut engine = pabi::engine::Engine::new(input, output);
     engine.uci_loop()
 }

--- a/src/chess/bitboard.rs
+++ b/src/chess/bitboard.rs
@@ -413,6 +413,18 @@ impl Pieces {
     }
 
     #[must_use]
+    pub(crate) const fn bitboard_for(&self, piece: PieceKind) -> Bitboard {
+        match piece {
+            PieceKind::King => self.king,
+            PieceKind::Queen => self.queens,
+            PieceKind::Rook => self.rooks,
+            PieceKind::Bishop => self.bishops,
+            PieceKind::Knight => self.knights,
+            PieceKind::Pawn => self.pawns,
+        }
+    }
+
+    #[must_use]
     pub(super) fn bitboard_for_mut(&mut self, piece: PieceKind) -> &mut Bitboard {
         match piece {
             PieceKind::King => &mut self.king,

--- a/src/chess/core.rs
+++ b/src/chess/core.rs
@@ -78,6 +78,89 @@ impl Move {
         Self::try_from(uci)
     }
 
+    /// Encodes the move as an index into the AlphaZero-style policy action
+    /// space of 64 × 73 = 4672 possible moves: for each source square there
+    /// are 73 "move planes" — 56 sliding moves (8 directions × 7 distances,
+    /// which also cover king moves, castling, pawn pushes/captures and queen
+    /// promotions), 8 knight moves and 9 underpromotions (3 directions × 3
+    /// pieces).
+    ///
+    /// The move must be encoded from the perspective of the player making it,
+    /// i.e. as if that player's pawns move up the board: flip Black's moves
+    /// with [`Move::flip_perspective`] before encoding. This compresses the
+    /// action space and lets the policy network share weights between colors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the move geometry is impossible for a chess piece (can not
+    /// happen for moves produced by the move generator).
+    #[must_use]
+    pub fn policy_index(&self) -> u16 {
+        /// Number of move planes per source square.
+        const NUM_PLANES: u16 = 73;
+        /// Knight move offsets as (rank, file) deltas, counterclockwise.
+        const KNIGHT_OFFSETS: [(i8, i8); 8] = [
+            (2, 1),
+            (1, 2),
+            (-1, 2),
+            (-2, 1),
+            (-2, -1),
+            (-1, -2),
+            (1, -2),
+            (2, -1),
+        ];
+
+        let (from, to) = (self.from(), self.to());
+        let rank_delta = to.rank() as i8 - from.rank() as i8;
+        let file_delta = to.file() as i8 - from.file() as i8;
+
+        let plane = if let Some(promotion) = self.promotion()
+            && promotion != Promotion::Queen
+        {
+            // Underpromotions: planes 64-72. Queen promotions are encoded as
+            // regular sliding moves.
+            let piece = match promotion {
+                Promotion::Knight => 0,
+                Promotion::Bishop => 1,
+                Promotion::Rook => 2,
+                Promotion::Queen => unreachable!("queen promotions use sliding planes"),
+            };
+            debug_assert!(rank_delta == 1 && file_delta.abs() <= 1);
+            let direction =
+                u16::try_from(file_delta + 1).expect("promotion file delta is in -1..=1");
+            64 + direction * 3 + piece
+        } else if let Some(knight_offset) = KNIGHT_OFFSETS
+            .iter()
+            .position(|&offset| offset == (rank_delta, file_delta))
+        {
+            // Knight moves: planes 56-63.
+            56 + knight_offset as u16
+        } else {
+            // Sliding moves: planes 0-55, 8 directions (clockwise starting
+            // from up) times 7 distances.
+            debug_assert!(
+                rank_delta == 0 || file_delta == 0 || rank_delta.abs() == file_delta.abs(),
+                "{self} is not a possible chess move"
+            );
+            let direction: u16 = match (rank_delta.signum(), file_delta.signum()) {
+                (1, 0) => 0,
+                (1, 1) => 1,
+                (0, 1) => 2,
+                (-1, 1) => 3,
+                (-1, 0) => 4,
+                (-1, -1) => 5,
+                (0, -1) => 6,
+                (1, -1) => 7,
+                _ => unreachable!("moves have different source and target squares"),
+            };
+            let distance = u16::try_from(rank_delta.abs().max(file_delta.abs()))
+                .expect("distance is in 1..=7");
+            direction * 7 + (distance - 1)
+        };
+
+        from as u16 * NUM_PLANES + plane
+    }
+
     /// Converts the move from the perspective of one player to the other, as if
     /// the other player's backrank is rank 1.
     ///
@@ -920,6 +1003,66 @@ mod tests {
             Move::from_uci("e7e8q").unwrap(),
             Move::new(Square::E7, Square::E8, Some(Promotion::Queen))
         );
+    }
+
+    #[test]
+    fn policy_index_known_values() {
+        // e2e4: source square 12, direction up (0), distance 2 -> plane 1.
+        assert_eq!(Move::from_uci("e2e4").unwrap().policy_index(), 12 * 73 + 1);
+        // Queen promotions use the sliding planes: direction up, distance 1.
+        assert_eq!(Move::from_uci("e7e8q").unwrap().policy_index(), 52 * 73);
+        // Knight underpromotion push: plane 64 + 1 * 3 + 0 = 67.
+        assert_eq!(
+            Move::from_uci("e7e8n").unwrap().policy_index(),
+            52 * 73 + 67
+        );
+        // Rook underpromotion capturing towards the a-file: plane 64 + 0 + 2.
+        assert_eq!(
+            Move::from_uci("e7d8r").unwrap().policy_index(),
+            52 * 73 + 66
+        );
+        // Knight move g1f3: offset (2, -1) is the last knight plane.
+        assert_eq!(Move::from_uci("g1f3").unwrap().policy_index(), 6 * 73 + 63);
+        // Short castling is encoded as a king slide two squares to the right.
+        assert_eq!(
+            Move::from_uci("e1g1").unwrap().policy_index(),
+            4 * 73 + 2 * 7 + 1
+        );
+    }
+
+    #[test]
+    fn policy_index_unique_and_bounded_for_legal_moves() {
+        use std::collections::HashSet;
+
+        use crate::chess::position::Position;
+        use crate::environment::Player;
+
+        // Positions covering castling, en passant, promotions and
+        // underpromotions for both colors.
+        for fen in [
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R b KQkq - 0 1",
+            "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+            "rnbqk1nr/ppp2ppp/8/4p3/2PpP3/5N2/PP1P1PPP/RNBQKB1R b KQkq c3 0 4",
+            "8/5P1k/8/8/8/8/K1p5/8 w - - 0 1",
+            "8/5P1k/8/8/8/8/K1p5/8 b - - 0 1",
+        ] {
+            let position = Position::from_fen(fen).unwrap();
+            let mut seen = HashSet::new();
+            for next_move in position.generate_moves() {
+                // Encode from the perspective of the player making the move.
+                let index = match position.us() {
+                    Player::White => next_move.policy_index(),
+                    Player::Black => next_move.flip_perspective().policy_index(),
+                };
+                assert!(index < 64 * 73, "index {index} out of bounds in {fen}");
+                assert!(
+                    seen.insert(index),
+                    "duplicate index {index} for {next_move} in {fen}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/chess/game.rs
+++ b/src/chess/game.rs
@@ -9,10 +9,12 @@ use crate::chess::zobrist::RepetitionTable;
 use crate::environment::{Action, Environment, GameResult, Observation, Player};
 
 impl Action for Move {
-    // Action space compression from lc0:
-    // https://github.com/LeelaChessZero/lc0/blob/master/src/chess/bitboard.cc
+    /// AlphaZero-style action space encoding, see [`Move::policy_index`].
+    ///
+    /// The move has to be from the perspective of the player making it: flip
+    /// Black's moves with [`Move::flip_perspective`] first.
     fn get_index(&self) -> u16 {
-        todo!();
+        self.policy_index()
     }
 }
 

--- a/src/chess/position.rs
+++ b/src/chess/position.rs
@@ -178,6 +178,37 @@ impl Position {
         self.hash
     }
 
+    pub(crate) const fn castling(&self) -> CastleRights {
+        self.castling
+    }
+
+    pub(crate) const fn en_passant(&self) -> Option<Square> {
+        self.en_passant_square
+    }
+
+    pub(crate) const fn halfmove_clock(&self) -> u8 {
+        self.halfmove_clock
+    }
+
+    /// Calls `f` for every piece on the board.
+    pub(crate) fn for_each_piece(&self, mut f: impl FnMut(Square, Piece)) {
+        for player in [Player::White, Player::Black] {
+            let pieces = self.pieces(player);
+            for (bitboard, kind) in [
+                (pieces.pawns, PieceKind::Pawn),
+                (pieces.knights, PieceKind::Knight),
+                (pieces.bishops, PieceKind::Bishop),
+                (pieces.rooks, PieceKind::Rook),
+                (pieces.queens, PieceKind::Queen),
+                (pieces.king, PieceKind::King),
+            ] {
+                for square in bitboard.iter() {
+                    f(square, Piece { player, kind });
+                }
+            }
+        }
+    }
+
     fn occupancy(&self, player: Player) -> Bitboard {
         self.pieces(player).all()
     }
@@ -1375,6 +1406,41 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    /// Plays random games and verifies that the incrementally updated state
+    /// (most importantly the Zobrist hash, which is maintained through many
+    /// hand-written paths in `make_move`: castling, en passant, promotions and
+    /// captures) always matches the state recomputed from scratch.
+    #[test]
+    fn incremental_hash_matches_recomputed_in_random_games() {
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        const GAMES: u64 = 100;
+        const MAX_PLIES: usize = 200;
+
+        for seed in 0..GAMES {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mut position = Position::starting();
+            for _ in 0..MAX_PLIES {
+                let moves = position.generate_moves();
+                if moves.is_empty() || position.halfmove_clock_expired() {
+                    break;
+                }
+                let next_move = moves[rng.random_range(0..moves.len())];
+                position.make_move(&next_move);
+                assert!(
+                    position.is_legal(),
+                    "illegal position after {next_move} (seed {seed}): {position}"
+                );
+                assert_eq!(
+                    position.hash(),
+                    position.compute_hash(),
+                    "incremental hash diverged after {next_move} (seed {seed}): {position}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn starting() {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,41 +7,75 @@
 //!
 //! [Universal Chess Interface]: https://www.chessprogramming.org/UCI
 use std::io::{BufRead, Write};
-use std::time::Duration;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::chess::core::Move;
 use crate::chess::position::Position;
+use crate::chess::zobrist::Key;
 use crate::engine::uci::Command;
 use crate::environment::Player;
+use crate::search::mcts;
 
 mod time_manager;
 mod uci;
 
+/// A search running in a background thread. The search can be stopped through
+/// the flag; joining the handle guarantees that `bestmove` has been printed.
+struct SearchThread {
+    stop: Arc<AtomicBool>,
+    handle: thread::JoinHandle<()>,
+    /// Whether the search would run forever unless stopped externally.
+    infinite: bool,
+}
+
 /// The Engine connects everything together and handles commands sent by UCI
 /// server. It is created when the program is started and implement the "main
 /// loop" via [`Engine::uci_loop`].
-pub struct Engine<'a, R: BufRead, W: Write> {
+pub struct Engine<R: BufRead, W: Write + Send + 'static> {
     /// Next search will start from this position.
     position: Position,
+    /// Zobrist hashes of all positions of the game so far, including the
+    /// current one. Used for detecting repetition draws during the search.
+    history: Vec<Key>,
     debug: bool,
-    // TODO: time_manager,
-    // TODO: transposition_table
+    /// Requested transposition table size in MB. Stored for the time when the
+    /// search gets a transposition table.
+    hash_size_mb: usize,
+    /// Number of search threads. Only single-threaded search is implemented so
+    /// far.
+    threads: usize,
+    /// Path to the directory with Syzygy tablebases. Stored for the time when
+    /// the search learns to probe them.
+    syzygy_tablebase: Option<PathBuf>,
     /// UCI commands will be read from this stream.
-    input: &'a mut R,
-    /// Responses to UCI commands will be written to this stream.
-    out: &'a mut W,
+    input: R,
+    /// Responses to UCI commands will be written to this stream. Shared with
+    /// the search thread, which reports progress and the best move.
+    out: Arc<Mutex<W>>,
+    search: Option<SearchThread>,
 }
 
-impl<'a, R: BufRead, W: Write> Engine<'a, R, W> {
+impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
     /// Creates a new instance of the engine with the starting position as the
     /// search root.
     #[must_use]
-    pub fn new(input: &'a mut R, out: &'a mut W) -> Self {
+    pub fn new(input: R, out: W) -> Self {
+        let position = Position::starting();
+        let history = vec![position.hash()];
         Self {
-            position: Position::starting(),
+            position,
+            history,
             debug: false,
+            hash_size_mb: 16,
+            threads: 1,
+            syzygy_tablebase: None,
             input,
-            out,
+            out: Arc::new(Mutex::new(out)),
+            search: None,
         }
     }
 
@@ -59,114 +93,284 @@ impl<'a, R: BufRead, W: Write> Engine<'a, R, W> {
     /// sure that the commands are in valid format. The engine won't spend too
     /// much time and effort on error recovery. If a command is not valid or
     /// unsupported yet, it will just be skipped.
-    ///
-    /// For example, if the UCI server sends a corrupted position or illegal
-    /// moves to the engine, the behavior is undefined.
     pub fn uci_loop(&mut self) -> anyhow::Result<()> {
         loop {
             let mut line = String::new();
             match self.input.read_line(&mut line) {
                 Ok(0) => break,
                 Ok(_) => {}
-                Err(e) => return Err(anyhow::Error::from(e).context("error reading UCI input")),
+                Err(e) => {
+                    self.stop_search();
+                    return Err(anyhow::Error::from(e).context("error reading UCI input"));
+                }
             }
             match Command::parse(&line) {
                 Command::Uci => self.handshake()?,
                 Command::Debug { on } => self.debug = on,
                 Command::IsReady => self.sync()?,
-                Command::SetOption { option, value } => match option {
-                    uci::EngineOption::Hash => match value {
-                        uci::OptionValue::Integer(_) => todo!(),
-                        uci::OptionValue::String(value) => writeln!(
-                            self.out,
-                            "info string Invalid value for Hash option: {value}"
-                        )?,
-                    },
-                    uci::EngineOption::Threads => todo!(),
-                    uci::EngineOption::SyzygyTablebase => todo!(),
-                },
-                Command::SetPosition { fen, moves } => self.set_position(fen, moves)?,
-                Command::NewGame => self.new_game()?,
+                Command::SetOption { option, value } => self.set_option(&option, value)?,
+                Command::SetPosition { fen, moves } => {
+                    if let Err(e) = self.set_position(fen, &moves) {
+                        self.send(&format!("info string invalid position: {e:#}"))?;
+                    }
+                }
+                Command::NewGame => self.new_game(),
                 Command::Go {
                     wtime,
                     btime,
                     winc,
                     binc,
-                } => self.go(wtime, btime, winc, binc)?,
-                Command::Stop => self.stop_search()?,
+                    movetime,
+                    depth,
+                    nodes,
+                    infinite,
+                } => {
+                    if depth.is_some() {
+                        self.send(
+                            "info string depth limit is not supported by the MCTS search and is \
+                             ignored",
+                        )?;
+                    }
+                    self.go(wtime, btime, winc, binc, movetime, nodes, infinite);
+                }
+                Command::Stop => self.stop_search(),
                 Command::Quit => {
-                    self.stop_search()?;
+                    // Let a search with finite limits run to completion so
+                    // that scripted input (where `quit` arrives right after
+                    // `go`) still produces a meaningful `bestmove`. GUIs that
+                    // want to terminate the search immediately send `stop`
+                    // first. Infinite searches are always interrupted.
+                    self.finish_search(false);
                     break;
                 }
-                Command::State => todo!(),
+                Command::State => self.state()?,
                 Command::Unknown(command) => {
-                    writeln!(self.out, "info string Unsupported command: {command}")?;
+                    let command = command.trim();
+                    if !command.is_empty() {
+                        self.send(&format!("info string Unsupported command: {command}"))?;
+                    }
                 }
             }
         }
         Ok(())
     }
 
+    /// Writes a line to the output stream and flushes it.
+    fn send(&self, line: &str) -> anyhow::Result<()> {
+        let mut out = self.out.lock().expect("output lock poisoned");
+        writeln!(out, "{line}")?;
+        out.flush()?;
+        Ok(())
+    }
+
     /// Responds to the `uci` handshake command by identifying the engine.
     fn handshake(&mut self) -> anyhow::Result<()> {
-        writeln!(
-            self.out,
+        self.send(&format!(
             "id name {} {}",
             env!("CARGO_PKG_NAME"),
             crate::engine_version()
-        )?;
-        writeln!(self.out, "id author {}", env!("CARGO_PKG_AUTHORS"))?;
-        writeln!(self.out, "uciok")?;
+        ))?;
+        self.send(&format!("id author {}", env!("CARGO_PKG_AUTHORS")))?;
+        self.send("option name Hash type spin default 16 min 1 max 1048576")?;
+        self.send("option name Threads type spin default 1 min 1 max 1")?;
+        self.send("option name SyzygyTablebase type string default <empty>")?;
+        self.send("uciok")?;
         Ok(())
     }
 
     /// Syncs with the UCI server by responding with `readyok`.
-    fn sync(&mut self) -> anyhow::Result<()> {
-        writeln!(self.out, "readyok")?;
-        Ok(())
+    fn sync(&self) -> anyhow::Result<()> {
+        self.send("readyok")
     }
 
-    fn new_game(&mut self) -> anyhow::Result<()> {
-        // TODO: Reset search state.
-        // TODO: Clear transposition table.
-        // TODO: Reset time manager.
-        Ok(())
-    }
-
-    /// Changes the position of the board to the one specified in the command.
-    fn set_position(&mut self, fen: Option<String>, moves: Vec<String>) -> anyhow::Result<()> {
-        match fen {
-            Some(fen) => self.position = Position::from_fen(&fen)?,
-            None => self.position = Position::starting(),
-        };
-        for next_move in moves {
-            let next_move = Move::from_uci(&next_move)
-                .map_err(|e| e.context(format!("invalid move in position command: {next_move}")))?;
-            self.position.make_move(&next_move);
+    fn set_option(
+        &mut self,
+        option: &uci::EngineOption,
+        value: uci::OptionValue,
+    ) -> anyhow::Result<()> {
+        match (option, value) {
+            (uci::EngineOption::Hash, uci::OptionValue::Integer(megabytes)) => {
+                self.hash_size_mb = megabytes.max(1);
+            }
+            (uci::EngineOption::Threads, uci::OptionValue::Integer(threads)) => {
+                if threads > 1 {
+                    self.send("info string only 1 search thread is supported for now")?;
+                }
+                self.threads = 1;
+            }
+            (uci::EngineOption::SyzygyTablebase, uci::OptionValue::String(path)) => {
+                let path = PathBuf::from(path);
+                if path.is_dir() {
+                    self.syzygy_tablebase = Some(path);
+                } else {
+                    self.send(&format!(
+                        "info string SyzygyTablebase path does not exist: {}",
+                        path.display()
+                    ))?;
+                }
+            }
+            (option, value) => {
+                self.send(&format!(
+                    "info string invalid value for option {option:?}: {value:?}"
+                ))?;
+            }
         }
         Ok(())
     }
 
+    fn new_game(&mut self) {
+        self.stop_search();
+        self.position = Position::starting();
+        self.history = vec![self.position.hash()];
+    }
+
+    /// Changes the position of the board to the one specified in the command.
+    /// Each move is checked to be legal in the position it is applied to.
+    fn set_position(&mut self, fen: Option<String>, moves: &[String]) -> anyhow::Result<()> {
+        self.stop_search();
+        let mut position = match fen {
+            Some(fen) => Position::from_fen(&fen)?,
+            None => Position::starting(),
+        };
+        let mut history = vec![position.hash()];
+        for next_move in moves {
+            let next_move = Move::from_uci(next_move)
+                .map_err(|e| e.context(format!("invalid move: {next_move}")))?;
+            if !position.generate_moves().contains(&next_move) {
+                anyhow::bail!("illegal move {next_move} in position {position}");
+            }
+            position.make_move(&next_move);
+            history.push(position.hash());
+        }
+        self.position = position;
+        self.history = history;
+        Ok(())
+    }
+
+    /// Starts the search in a background thread. The thread reports progress
+    /// through `info` lines and always finishes by printing `bestmove`.
     fn go(
         &mut self,
         wtime: Option<Duration>,
         btime: Option<Duration>,
         winc: Option<Duration>,
         binc: Option<Duration>,
-    ) -> anyhow::Result<()> {
-        let (time, increment) = match self.position.us() {
-            Player::White => (wtime, winc),
-            Player::Black => (btime, binc),
+        movetime: Option<Duration>,
+        nodes: Option<u64>,
+        infinite: bool,
+    ) {
+        self.stop_search();
+
+        let mut limits = mcts::Limits {
+            move_time: movetime,
+            nodes,
+            infinite,
         };
-        todo!();
+        if limits.move_time.is_none() && !infinite {
+            let (time, increment) = match self.position.us() {
+                Player::White => (wtime, winc),
+                Player::Black => (btime, binc),
+            };
+            if let Some(time) = time {
+                limits.move_time = Some(time_manager::time_budget(
+                    time,
+                    increment.unwrap_or_default(),
+                ));
+            }
+        }
+        // `go` without any limits means searching until told to stop.
+        if limits.move_time.is_none() && limits.nodes.is_none() {
+            limits.infinite = true;
+        }
+
+        let infinite = limits.infinite;
+        let stop = Arc::new(AtomicBool::new(false));
+        let position = self.position.clone();
+        let history = self.history.clone();
+        let out = Arc::clone(&self.out);
+        let search_stop = Arc::clone(&stop);
+
+        let handle = thread::spawn(move || {
+            let result = mcts::search(&position, &history, &limits, &search_stop, |info| {
+                let mut out = out.lock().expect("output lock poisoned");
+                let _ = writeln!(out, "{info}");
+                let _ = out.flush();
+            });
+            let mut out = out.lock().expect("output lock poisoned");
+            match result.best_move {
+                Some(best_move) => {
+                    let _ = writeln!(out, "bestmove {best_move}");
+                }
+                None => {
+                    let _ = writeln!(out, "bestmove (none)");
+                }
+            }
+            let _ = out.flush();
+        });
+
+        self.search = Some(SearchThread {
+            stop,
+            handle,
+            infinite,
+        });
     }
 
-    /// Stops the search immediately.
-    ///
-    /// NOTE: This is a no-op for now.
-    fn stop_search(&mut self) -> anyhow::Result<()> {
-        // TODO: Implement this method.
+    /// Stops the running search (if any) and waits for it to print `bestmove`.
+    fn stop_search(&mut self) {
+        self.finish_search(true);
+    }
+
+    /// Waits for the running search (if any) to print `bestmove`. When
+    /// `force` is set, the search is interrupted; otherwise it runs until its
+    /// own limits expire (infinite searches are interrupted regardless, as
+    /// they have no limits to expire).
+    fn finish_search(&mut self, force: bool) {
+        if let Some(search) = self.search.take() {
+            if force || search.infinite {
+                search.stop.store(true, Ordering::Relaxed);
+            }
+            let _ = search.handle.join();
+        }
+    }
+
+    /// Responds to the non-standard `state` command with debugging
+    /// information about the engine state.
+    fn state(&self) -> anyhow::Result<()> {
+        self.send(&format!("info string position fen {}", self.position))?;
+        self.send(&format!(
+            "info string static eval cp {}",
+            crate::evaluation::evaluate(&self.position)
+        ))?;
+        self.send(&format!(
+            "info string legal moves {}",
+            self.position.generate_moves().len()
+        ))?;
+        self.send(&format!(
+            "info string game plies {}",
+            self.history.len() - 1
+        ))?;
+        self.send(&format!("info string debug {}", self.debug))?;
+        self.send(&format!("info string option Hash {}", self.hash_size_mb))?;
+        self.send(&format!("info string option Threads {}", self.threads))?;
+        self.send(&format!(
+            "info string option SyzygyTablebase {}",
+            self.syzygy_tablebase
+                .as_ref()
+                .map_or_else(|| "<empty>".to_string(), |p| p.display().to_string())
+        ))?;
+        self.send(&format!(
+            "info string search running {}",
+            self.search
+                .as_ref()
+                .is_some_and(|s| !s.handle.is_finished())
+        ))?;
         Ok(())
+    }
+}
+
+impl<R: BufRead, W: Write + Send + 'static> Drop for Engine<R, W> {
+    fn drop(&mut self) {
+        self.stop_search();
     }
 }
 
@@ -183,7 +387,56 @@ impl<'a, R: BufRead, W: Write> Engine<'a, R, W> {
 ///
 /// [requirement for OpenBench]: https://github.com/AndyGrant/OpenBench/wiki/Requirements-For-Public-Engines#basic-requirements
 pub fn openbench() {
-    todo!()
-}
+    const NODES_PER_POSITION: u64 = 5000;
+    const POSITIONS: &[&str] = &[
+        // Starting position.
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        // Italian game.
+        "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3",
+        // Kiwipete: a tactically rich middlegame position.
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        // Rook endgame.
+        "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+        // Promotion-heavy position.
+        "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+        // Closed middlegame.
+        "r4rk1/1pp1qppp/p1np1n2/2b1p1b1/2B1P1B1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10",
+        // Queen vs rook endgame.
+        "4k3/8/8/5r2/4KQ2/8/8/8 w - - 0 1",
+        // King and pawn endgame.
+        "4k3/8/8/8/8/8/4P3/4K3 w - - 0 1",
+    ];
 
-// TODO: Add extensive test suite for the UCI protocol implementation.
+    let start = Instant::now();
+    let mut total_nodes = 0;
+    for fen in POSITIONS {
+        let position = Position::from_fen(fen).expect("bench positions are valid");
+        let limits = mcts::Limits {
+            nodes: Some(NODES_PER_POSITION),
+            ..mcts::Limits::default()
+        };
+        let stop = AtomicBool::new(false);
+        let result = mcts::search(&position, &[position.hash()], &limits, &stop, |_| {});
+        total_nodes += result.nodes;
+        println!(
+            "info string bench bestmove {} for {fen}",
+            result
+                .best_move
+                .map_or_else(|| "(none)".to_string(), |m| m.to_string())
+        );
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        reason = "nps can not realistically overflow or be negative"
+    )]
+    let nps = if elapsed > 0.0 {
+        (total_nodes as f64 / elapsed) as u64
+    } else {
+        0
+    };
+    println!("{total_nodes} nodes {nps} nps");
+}

--- a/src/engine/time_manager.rs
+++ b/src/engine/time_manager.rs
@@ -1,1 +1,51 @@
+//! Decides how much time to spend on a move given the game time controls.
 
+use std::time::Duration;
+
+/// A safety margin subtracted from the remaining time to account for the
+/// communication overhead between the engine and the tournament manager/GUI.
+const MOVE_OVERHEAD: Duration = Duration::from_millis(10);
+
+/// Returns the time budget for the next move.
+///
+/// The heuristic assumes the game will last around 20 more moves and spends
+/// the increment eagerly, while never using more than half of the remaining
+/// time on a single move.
+#[must_use]
+pub(super) fn time_budget(remaining: Duration, increment: Duration) -> Duration {
+    const MINIMUM_BUDGET: Duration = Duration::from_millis(1);
+    let usable = remaining.saturating_sub(MOVE_OVERHEAD);
+    let budget = usable / 20 + increment / 2;
+    budget.clamp(MINIMUM_BUDGET, (usable / 2).max(MINIMUM_BUDGET))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_is_a_fraction_of_remaining_time() {
+        let budget = time_budget(Duration::from_secs(60), Duration::ZERO);
+        assert!(budget >= Duration::from_secs(2));
+        assert!(budget <= Duration::from_secs(30));
+    }
+
+    #[test]
+    fn increment_is_partially_spent() {
+        let with_increment = time_budget(Duration::from_secs(60), Duration::from_secs(2));
+        let without_increment = time_budget(Duration::from_secs(60), Duration::ZERO);
+        assert!(with_increment > without_increment);
+    }
+
+    #[test]
+    fn never_exceeds_half_of_remaining_time() {
+        let budget = time_budget(Duration::from_millis(100), Duration::from_secs(10));
+        assert!(budget <= Duration::from_millis(50));
+    }
+
+    #[test]
+    fn minimal_budget_with_no_time_left() {
+        let budget = time_budget(Duration::ZERO, Duration::ZERO);
+        assert_eq!(budget, Duration::from_millis(1));
+    }
+}

--- a/src/engine/uci.rs
+++ b/src/engine/uci.rs
@@ -21,6 +21,10 @@ pub(super) enum Command {
         btime: Option<Duration>,
         winc: Option<Duration>,
         binc: Option<Duration>,
+        movetime: Option<Duration>,
+        depth: Option<u32>,
+        nodes: Option<u64>,
+        infinite: bool,
     },
     Stop,
     Quit,
@@ -50,6 +54,10 @@ fn parse_go(parts: &[&str]) -> Command {
     let mut btime = None;
     let mut winc = None;
     let mut binc = None;
+    let mut movetime = None;
+    let mut depth = None;
+    let mut nodes = None;
+    let mut infinite = false;
 
     let mut i = 1;
 
@@ -72,9 +80,25 @@ fn parse_go(parts: &[&str]) -> Command {
                 binc = parts[i + 1].parse().map(Duration::from_millis).ok();
                 i += 2;
             }
-            // Tokens without a value (e.g. "infinite" or "ponder") and
-            // unsupported ones are skipped one at a time so that they can not
-            // swallow a keyword that follows them.
+            "movetime" if i + 1 < parts.len() => {
+                movetime = parts[i + 1].parse().map(Duration::from_millis).ok();
+                i += 2;
+            }
+            "depth" if i + 1 < parts.len() => {
+                depth = parts[i + 1].parse().ok();
+                i += 2;
+            }
+            "nodes" if i + 1 < parts.len() => {
+                nodes = parts[i + 1].parse().ok();
+                i += 2;
+            }
+            "infinite" => {
+                infinite = true;
+                i += 1;
+            }
+            // Tokens without a value (e.g. "ponder") and unsupported ones are
+            // skipped one at a time so that they can not swallow a keyword
+            // that follows them.
             _ => i += 1,
         }
     }
@@ -84,6 +108,10 @@ fn parse_go(parts: &[&str]) -> Command {
         btime,
         winc,
         binc,
+        movetime,
+        depth,
+        nodes,
+        infinite,
     }
 }
 
@@ -252,6 +280,10 @@ mod tests {
                 btime: Some(Duration::from_millis(300_000)),
                 winc: Some(Duration::from_millis(10000)),
                 binc: Some(Duration::from_millis(10000)),
+                movetime: None,
+                depth: None,
+                nodes: None,
+                infinite: false,
             }
         );
 
@@ -262,6 +294,10 @@ mod tests {
                 btime: None,
                 winc: None,
                 binc: None,
+                movetime: None,
+                depth: None,
+                nodes: None,
+                infinite: false,
             }
         );
 
@@ -274,6 +310,10 @@ mod tests {
                 btime: Some(Duration::from_millis(2000)),
                 winc: None,
                 binc: None,
+                movetime: None,
+                depth: None,
+                nodes: None,
+                infinite: false,
             }
         );
     }
@@ -298,6 +338,49 @@ mod tests {
         assert_eq!(
             Command::parse("unknown command"),
             Command::Unknown("unknown command".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_go_limits() {
+        assert_eq!(
+            Command::parse("go movetime 5000"),
+            Command::Go {
+                wtime: None,
+                btime: None,
+                winc: None,
+                binc: None,
+                movetime: Some(Duration::from_millis(5000)),
+                depth: None,
+                nodes: None,
+                infinite: false,
+            }
+        );
+        assert_eq!(
+            Command::parse("go depth 12 nodes 100000"),
+            Command::Go {
+                wtime: None,
+                btime: None,
+                winc: None,
+                binc: None,
+                movetime: None,
+                depth: Some(12),
+                nodes: Some(100_000),
+                infinite: false,
+            }
+        );
+        assert_eq!(
+            Command::parse("go infinite"),
+            Command::Go {
+                wtime: None,
+                btime: None,
+                winc: None,
+                binc: None,
+                movetime: None,
+                depth: None,
+                nodes: None,
+                infinite: true,
+            }
         );
     }
 }

--- a/src/evaluation/features.rs
+++ b/src/evaluation/features.rs
@@ -1,1 +1,151 @@
-//! Extracts features from the position.
+//! Extracts features from the position to be used as the input of the
+//! policy+value Neural Network.
+//!
+//! All features are encoded from the perspective of the player to move: the
+//! board is flipped vertically for Black, so that "our" pawns always move up.
+//! This halves the input space the network has to learn and matches the
+//! encoding of the action space ([`crate::chess::core::Move::policy_index`]).
+#![allow(
+    dead_code,
+    reason = "Neural Network plumbing that is not wired into the search yet"
+)]
+
+use crate::chess::bitboard::Bitboard;
+use crate::chess::core::{CastleRights, File, PieceKind};
+use crate::chess::position::Position;
+use crate::environment::Player;
+
+/// Number of piece occupancy planes: 6 piece kinds for each of the two
+/// players.
+pub(crate) const NUM_PIECE_PLANES: usize = 12;
+
+/// Input features of a position from the perspective of the player to move.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Features {
+    /// Piece occupancy bitboards: planes 0-5 are our pieces in `PieceKind`
+    /// order (pawn to king), planes 6-11 are the opponent's pieces in the same
+    /// order. The board is always oriented so that our pawns move towards
+    /// higher ranks.
+    pub(crate) pieces: [Bitboard; NUM_PIECE_PLANES],
+    /// Castling availability for both sides.
+    pub(crate) our_short_castle: bool,
+    pub(crate) our_long_castle: bool,
+    pub(crate) their_short_castle: bool,
+    pub(crate) their_long_castle: bool,
+    /// File of the en passant target square, if any. The rank is implied: it
+    /// is always the 6th rank from our perspective.
+    pub(crate) en_passant_file: Option<File>,
+    /// Number of halfmoves since the last capture or pawn move (the 50-move
+    /// rule counter).
+    pub(crate) halfmove_clock: u8,
+}
+
+impl Features {
+    /// Extracts the features from the position.
+    pub(crate) fn extract(position: &Position) -> Self {
+        let (us, them) = (position.us(), position.them());
+        let flip = us == Player::Black;
+
+        let mut pieces = [Bitboard::empty(); NUM_PIECE_PLANES];
+        for (side, player) in [(0, us), (6, them)] {
+            let player_pieces = position.pieces(player);
+            for kind in [
+                PieceKind::Pawn,
+                PieceKind::Knight,
+                PieceKind::Bishop,
+                PieceKind::Rook,
+                PieceKind::Queen,
+                PieceKind::King,
+            ] {
+                let bitboard = player_pieces.bitboard_for(kind);
+                pieces[side + kind as usize] = if flip {
+                    bitboard.flip_perspective()
+                } else {
+                    bitboard
+                };
+            }
+        }
+
+        let castling = position.castling();
+        let (our_short, our_long, their_short, their_long) = match us {
+            Player::White => (
+                CastleRights::WHITE_SHORT,
+                CastleRights::WHITE_LONG,
+                CastleRights::BLACK_SHORT,
+                CastleRights::BLACK_LONG,
+            ),
+            Player::Black => (
+                CastleRights::BLACK_SHORT,
+                CastleRights::BLACK_LONG,
+                CastleRights::WHITE_SHORT,
+                CastleRights::WHITE_LONG,
+            ),
+        };
+
+        Self {
+            pieces,
+            our_short_castle: castling.contains(our_short),
+            our_long_castle: castling.contains(our_long),
+            their_short_castle: castling.contains(their_short),
+            their_long_castle: castling.contains(their_long),
+            // A vertical flip does not change the file.
+            en_passant_file: position.en_passant().map(|square| square.file()),
+            halfmove_clock: position.halfmove_clock(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn starting_position_is_symmetric() {
+        // The starting position looks identical for both players, so the
+        // features from White's and Black's perspective must be equal.
+        let white_to_move = Features::extract(&Position::starting());
+        let black_to_move = Features::extract(
+            &Position::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1")
+                .unwrap(),
+        );
+        assert_eq!(white_to_move, black_to_move);
+
+        // Our pawns occupy the second rank from our perspective.
+        assert_eq!(
+            white_to_move.pieces[PieceKind::Pawn as usize],
+            Bitboard::from_bits(0x0000_0000_0000_FF00)
+        );
+        assert!(white_to_move.our_short_castle);
+        assert!(white_to_move.their_long_castle);
+        assert_eq!(white_to_move.en_passant_file, None);
+    }
+
+    #[test]
+    fn black_perspective_is_flipped() {
+        // After 1. e4 it is Black to move: from Black's perspective the white
+        // e4 pawn is a "their" pawn on the 5th rank (e5 after the flip).
+        let position =
+            Position::from_fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1")
+                .unwrap();
+        let features = Features::extract(&position);
+        let their_pawns = features.pieces[6 + PieceKind::Pawn as usize];
+        assert!(
+            their_pawns.bits() & (1 << 36) != 0,
+            "expected an opponent pawn on e5 after the flip"
+        );
+    }
+
+    #[test]
+    fn en_passant_and_castling() {
+        let position = Position::from_fen(
+            "rnbqk1nr/p3bppp/1p2p3/2ppP3/3P4/P7/1PP1NPPP/R1BQKBNR w KQkq c6 0 7",
+        )
+        .unwrap();
+        let features = Features::extract(&position);
+        assert_eq!(features.en_passant_file, Some(File::C));
+        assert!(features.our_short_castle);
+        assert!(features.their_short_castle);
+    }
+}

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -3,7 +3,102 @@
 //!
 //! For convenience, the score is returned in centipawn units.
 //!
+//! The current implementation is a classical [Tapered Eval] based on the
+//! [PeSTO] piece-square tables. It serves as a baseline value function for the
+//! search until the Neural Network evaluation is implemented.
+//!
 //! [evaluation]: https://www.chessprogramming.org/Evaluation
+//! [Tapered Eval]: https://www.chessprogramming.org/Tapered_Eval
+//! [PeSTO]: https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function
 
 pub(crate) mod features;
 pub(crate) mod network;
+
+use crate::chess::position::Position;
+use crate::environment::Player;
+
+/// Piece-square tables combined with material values, generated in `build.rs`.
+/// Indexed by [`crate::chess::core::Piece::plane()`] and square.
+static MIDDLEGAME_TABLE: [[i32; 64]; 12] =
+    include!(concat!(env!("OUT_DIR"), "/pesto_middlegame_table"));
+static ENDGAME_TABLE: [[i32; 64]; 12] = include!(concat!(env!("OUT_DIR"), "/pesto_endgame_table"));
+
+/// Game phase contribution of each piece kind in `PieceKind` order (pawn to
+/// king). The maximum phase (all pieces on the board) is 24.
+const PHASE_WEIGHT: [i32; 6] = [0, 1, 1, 2, 4, 0];
+const MAX_PHASE: i32 = 24;
+
+/// Returns the static evaluation of the position in centipawns from the
+/// perspective of the player to move: positive means the player to move is
+/// better.
+#[must_use]
+pub fn evaluate(position: &Position) -> i32 {
+    let mut middlegame = 0;
+    let mut endgame = 0;
+    let mut phase = 0;
+
+    position.for_each_piece(|square, piece| {
+        let plane = piece.plane();
+        let sign = match piece.player {
+            Player::White => 1,
+            Player::Black => -1,
+        };
+        middlegame += sign * MIDDLEGAME_TABLE[plane][square as usize];
+        endgame += sign * ENDGAME_TABLE[plane][square as usize];
+        phase += PHASE_WEIGHT[piece.kind as usize];
+    });
+
+    // Guard against promotions pushing the phase above the cap.
+    let phase = phase.min(MAX_PHASE);
+    let white_score = (middlegame * phase + endgame * (MAX_PHASE - phase)) / MAX_PHASE;
+
+    match position.us() {
+        Player::White => white_score,
+        Player::Black => -white_score,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn starting_position_is_balanced() {
+        assert_eq!(evaluate(&Position::starting()), 0);
+    }
+
+    #[test]
+    fn material_advantage() {
+        // White is up a queen: strongly positive for White to move, strongly
+        // negative for Black to move.
+        let up_a_queen = "rnb1kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        let position = Position::from_fen(up_a_queen).unwrap();
+        assert!(evaluate(&position) > 500);
+
+        let up_a_queen_black_to_move = "rnb1kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1";
+        let position = Position::from_fen(up_a_queen_black_to_move).unwrap();
+        assert!(evaluate(&position) < -500);
+    }
+
+    #[test]
+    fn symmetric_for_both_players() {
+        // The same position should evaluate to the exact opposite score when
+        // only the side to move is flipped.
+        let fen_white = "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3";
+        let fen_black = "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 2 3";
+        let white_to_move = evaluate(&Position::from_fen(fen_white).unwrap());
+        let black_to_move = evaluate(&Position::from_fen(fen_black).unwrap());
+        assert_eq!(white_to_move, -black_to_move);
+    }
+
+    #[test]
+    fn advanced_pawns_are_valuable() {
+        // A white pawn on the 7th rank should be worth much more than one on
+        // its starting square.
+        let advanced = evaluate(&Position::from_fen("4k3/2P5/8/8/8/8/8/4K3 w - - 0 1").unwrap());
+        let starting = evaluate(&Position::from_fen("4k3/8/8/8/8/8/2P5/4K3 w - - 0 1").unwrap());
+        assert!(advanced > starting);
+    }
+}

--- a/src/search/mcts.rs
+++ b/src/search/mcts.rs
@@ -1,39 +1,416 @@
-/// Parameters for MCTS search algorithm.
-#[derive(Debug)]
-struct Config {
-    /// Number of search iterations to perform.
-    iterations: u16,
-    /// Number of threads to use.
-    threads: u16,
-    /// Exploration constant ($c_puct$ in the original paper).
-    cpuct: f32,
-    temperature: f32,
-    /// Dirichlet distribution parameter for action selection at the root node.
-    dirichlet_alpha: f32,
-    /// Fraction of the dirichlet noise to add to the prior probabilities
-    /// ($\epsilon$ in the original paper).
-    dirichlet_exploration_weight: f32,
+//! Implementation of the AlphaZero-style [Monte Carlo Tree Search]:
+//!
+//! 1. Selection: starting from the root, descend by picking the most promising
+//!    child ([`crate::search::policy`]) until a leaf is reached.
+//! 2. Expansion: generate the leaf's children and assign prior probabilities.
+//! 3. Evaluation: score the leaf with the value function
+//!    ([`crate::evaluation`]); terminal positions get their exact game value.
+//!    There are no random playouts, matching the AlphaZero variant of MCTS.
+//! 4. Backup: propagate the value up the path, flipping the sign at each level
+//!    (the value of a position for one player is the negation of its value for
+//!    the opponent).
+//!
+//! [Monte Carlo Tree Search]: https://en.wikipedia.org/wiki/Monte_Carlo_tree_search
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use super::policy;
+use super::tree::{NodeId, ROOT_ID, Tree};
+use crate::chess::core::Move;
+use crate::chess::position::Position;
+use crate::chess::zobrist::Key;
+use crate::evaluation;
+
+/// Exploration constant ($c_{puct}$ in the AlphaZero paper).
+const CPUCT: f32 = 1.5;
+
+/// How often (in search iterations) the time limit is checked and search info
+/// is potentially reported.
+const CHECK_INTERVAL: u64 = 128;
+
+/// Maximum length of the principal variation to report.
+const MAX_PV_LENGTH: usize = 16;
+
+/// Limits controlling when the search stops. Multiple limits can be active at
+/// once: the search stops as soon as any of them is reached. Regardless of the
+/// limits, the search can always be stopped externally through the stop flag.
+#[derive(Debug, Clone, Default)]
+pub struct Limits {
+    /// Hard limit on the search wall clock time.
+    pub move_time: Option<Duration>,
+    /// Limit on the number of search iterations (playouts).
+    pub nodes: Option<u64>,
+    /// If set, the search runs until stopped externally, ignoring other
+    /// limits.
+    pub infinite: bool,
 }
 
-/// Implements AlphaZero's Monte Carlo Tree Search algorithm.
+/// Final result of a search.
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    /// The move the engine considers best. `None` if the root position has no
+    /// legal moves.
+    pub best_move: Option<Move>,
+    /// Number of search iterations performed.
+    pub nodes: u64,
+}
+
+/// Searches the position and returns the best move.
 ///
-/// 1. Selection: Start from root node and select the most promising child node.
-/// 2. Expansion: If the selected node is not a leaf node, expand it by adding a
-///    new child node.
-/// 3. Simulation: Run a simulation from the child node until a result is
-///    reached.
-/// 4. Backpropagation: Update the nodes on the path from the root to the
-///    selected node with the result.
-fn search(iterations: usize) {
-    for _ in 0..iterations {
-        todo!()
+/// `history` should contain the Zobrist hashes of all positions of the game so
+/// far (including the root position): it is used to score repetitions as
+/// draws.
+///
+/// `on_info` is called with UCI `info` lines as the search progresses.
+pub fn search(
+    root_position: &Position,
+    history: &[Key],
+    limits: &Limits,
+    stop: &AtomicBool,
+    mut on_info: impl FnMut(&str),
+) -> SearchResult {
+    let root_moves = root_position.generate_moves();
+    if root_moves.is_empty() {
+        return SearchResult {
+            best_move: None,
+            nodes: 0,
+        };
+    }
+
+    let mut tree = Tree::new();
+    #[allow(clippy::cast_precision_loss, reason = "the number of moves is small")]
+    let prior = 1.0 / root_moves.len() as f32;
+    for next_move in &root_moves {
+        let _ = tree.add_child(ROOT_ID, *next_move, prior);
+    }
+    tree.node_mut(ROOT_ID).expanded = true;
+
+    let start = Instant::now();
+    let mut iterations = 0u64;
+    let mut max_depth = 0usize;
+    let mut last_report = Instant::now();
+
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        if !limits.infinite {
+            if let Some(nodes) = limits.nodes
+                && iterations >= nodes
+            {
+                break;
+            }
+            if let Some(move_time) = limits.move_time
+                && start.elapsed() >= move_time
+            {
+                break;
+            }
+        }
+
+        let depth = simulate(&mut tree, root_position, history);
+        max_depth = max_depth.max(depth);
+        iterations += 1;
+
+        if iterations.is_multiple_of(CHECK_INTERVAL)
+            && last_report.elapsed() >= Duration::from_secs(1)
+        {
+            on_info(&info_line(&tree, iterations, max_depth, start));
+            last_report = Instant::now();
+        }
+    }
+
+    on_info(&info_line(&tree, iterations, max_depth, start));
+
+    SearchResult {
+        best_move: Some(best_move(&tree)),
+        nodes: iterations,
     }
 }
 
-fn backup() {
-    todo!()
+/// Runs a single search iteration (selection, expansion, evaluation, backup)
+/// and returns the depth reached.
+fn simulate(tree: &mut Tree, root_position: &Position, history: &[Key]) -> usize {
+    let mut position = root_position.clone();
+    let mut path = vec![ROOT_ID];
+    let mut path_hashes: Vec<Key> = Vec::new();
+    let mut node_id = ROOT_ID;
+
+    // Selection: descend until a terminal or unexpanded node.
+    while tree.node(node_id).terminal.is_none() && tree.node(node_id).expanded {
+        let child_id = policy::select_child(tree, node_id, CPUCT);
+        let action = tree
+            .node(child_id)
+            .action
+            .expect("non-root nodes always have an action");
+        position.make_move(&action);
+        path_hashes.push(position.hash());
+        path.push(child_id);
+        node_id = child_id;
+    }
+
+    // Expansion and evaluation.
+    let value = match tree.node(node_id).terminal {
+        Some(value) => value,
+        None => expand_and_evaluate(tree, node_id, &position, &path_hashes, history),
+    };
+
+    backup(tree, &path, value);
+    path.len() - 1
 }
 
-fn simulate() {
-    todo!()
+/// Expands the leaf and returns its value from the perspective of the player
+/// to move at the leaf. Terminal values are cached in the node: the path from
+/// the root to a node is unique, so the terminal status (including draws by
+/// repetition) is deterministic.
+fn expand_and_evaluate(
+    tree: &mut Tree,
+    node_id: NodeId,
+    position: &Position,
+    path_hashes: &[Key],
+    history: &[Key],
+) -> f64 {
+    let moves = position.generate_moves();
+    if moves.is_empty() {
+        // Checkmate is the worst outcome for the player to move; stalemate is
+        // a draw.
+        let value = if position.in_check() { -1.0 } else { 0.0 };
+        tree.node_mut(node_id).terminal = Some(value);
+        return value;
+    }
+
+    let is_root = path_hashes.is_empty();
+    if !is_root {
+        if position.halfmove_clock_expired() || position.is_insufficient_material() {
+            tree.node_mut(node_id).terminal = Some(0.0);
+            return 0.0;
+        }
+        // Score any repetition of an earlier position (in the game or in the
+        // current search path) as an immediate draw.
+        let current = *path_hashes.last().expect("non-root path is not empty");
+        let earlier = &path_hashes[..path_hashes.len() - 1];
+        if earlier.contains(&current) || history.contains(&current) {
+            tree.node_mut(node_id).terminal = Some(0.0);
+            return 0.0;
+        }
+    }
+
+    #[allow(clippy::cast_precision_loss, reason = "the number of moves is small")]
+    let prior = 1.0 / moves.len() as f32;
+    for next_move in &moves {
+        let _ = tree.add_child(node_id, *next_move, prior);
+    }
+    tree.node_mut(node_id).expanded = true;
+
+    value_from_centipawns(evaluation::evaluate(position))
+}
+
+/// Propagates the value up the path. `value` is from the perspective of the
+/// player to move at the leaf (the last node in the path); node statistics
+/// store values from the parent's perspective, so the sign flips at each
+/// level.
+fn backup(tree: &mut Tree, path: &[NodeId], leaf_value: f64) {
+    let mut value = leaf_value;
+    for &node_id in path.iter().rev() {
+        let node = tree.node_mut(node_id);
+        node.visits += 1;
+        node.total_value -= value;
+        value = -value;
+    }
+}
+
+/// Returns the root child with the most visits, breaking ties by mean value.
+fn best_move(tree: &Tree) -> Move {
+    let root = tree.node(ROOT_ID);
+    let best = root
+        .children
+        .iter()
+        .max_by(|&&a, &&b| {
+            let (a, b) = (tree.node(a), tree.node(b));
+            a.visits
+                .cmp(&b.visits)
+                .then(a.mean_value().total_cmp(&b.mean_value()))
+        })
+        .expect("root is always expanded");
+    tree.node(*best).action.expect("root children have actions")
+}
+
+/// Maps a centipawn score to the value domain `[-1, 1]` through the logistic
+/// "win probability" curve.
+fn value_from_centipawns(centipawns: i32) -> f64 {
+    2.0 / (1.0 + 10f64.powf(-f64::from(centipawns) / 400.0)) - 1.0
+}
+
+/// Inverse of [`value_from_centipawns`], used for reporting the score.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "the score is clamped to a small range"
+)]
+fn centipawns_from_value(value: f64) -> i32 {
+    let value = value.clamp(-0.9999, 0.9999);
+    (400.0 * ((1.0 + value) / (1.0 - value)).log10()).round() as i32
+}
+
+fn info_line(tree: &Tree, iterations: u64, max_depth: usize, start: Instant) -> String {
+    let elapsed = start.elapsed();
+    let millis = elapsed.as_millis();
+    let nps = if elapsed.as_secs_f64() > 0.0 {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_precision_loss,
+            clippy::cast_sign_loss,
+            reason = "nps can not realistically overflow or be negative"
+        )]
+        let nps = (iterations as f64 / elapsed.as_secs_f64()) as u64;
+        nps
+    } else {
+        0
+    };
+
+    let root = tree.node(ROOT_ID);
+    let best = root
+        .children
+        .iter()
+        .max_by_key(|&&child| tree.node(child).visits)
+        .expect("root is always expanded");
+    let score = centipawns_from_value(tree.node(*best).mean_value());
+
+    let mut pv = String::new();
+    let mut node_id = ROOT_ID;
+    for _ in 0..MAX_PV_LENGTH {
+        let node = tree.node(node_id);
+        if node.children.is_empty() {
+            break;
+        }
+        let next = *node
+            .children
+            .iter()
+            .max_by_key(|&&child| tree.node(child).visits)
+            .expect("children are not empty");
+        if tree.node(next).visits == 0 {
+            break;
+        }
+        if !pv.is_empty() {
+            pv.push(' ');
+        }
+        pv.push_str(
+            &tree
+                .node(next)
+                .action
+                .expect("non-root nodes have actions")
+                .to_string(),
+        );
+        node_id = next;
+    }
+    if pv.is_empty() {
+        // Even with zero completed iterations there is a legal first move.
+        pv = tree
+            .node(root.children[0])
+            .action
+            .expect("root children have actions")
+            .to_string();
+    }
+
+    format!(
+        "info depth {max_depth} nodes {iterations} nps {nps} time {millis} score cp {score} pv \
+         {pv}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    fn run(fen: &str, limits: &Limits) -> SearchResult {
+        let position = Position::from_fen(fen).unwrap();
+        let history = vec![position.hash()];
+        let stop = AtomicBool::new(false);
+        search(&position, &history, limits, &stop, |_| {})
+    }
+
+    #[test]
+    fn returns_legal_move_from_starting_position() {
+        let position = Position::starting();
+        let history = vec![position.hash()];
+        let stop = AtomicBool::new(false);
+        let result = search(
+            &position,
+            &history,
+            &Limits {
+                nodes: Some(100),
+                ..Limits::default()
+            },
+            &stop,
+            |_| {},
+        );
+        let best = result.best_move.expect("starting position has moves");
+        assert!(position.generate_moves().contains(&best));
+    }
+
+    #[test]
+    fn finds_backrank_mate_in_one() {
+        let result = run(
+            "6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1",
+            &Limits {
+                nodes: Some(3000),
+                ..Limits::default()
+            },
+        );
+        assert_eq!(result.best_move.unwrap().to_string(), "a1a8");
+    }
+
+    #[test]
+    fn no_moves_in_checkmate() {
+        // Black is checkmated: no moves to search.
+        let result = run(
+            "rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 4 3",
+            &Limits::default(),
+        );
+        assert!(result.best_move.is_none());
+    }
+
+    #[test]
+    fn stops_immediately_when_stop_flag_is_set() {
+        let position = Position::starting();
+        let history = vec![position.hash()];
+        let stop = AtomicBool::new(true);
+        // Infinite search with a pre-set stop flag has to terminate and still
+        // produce a legal move.
+        let result = search(
+            &position,
+            &history,
+            &Limits {
+                infinite: true,
+                ..Limits::default()
+            },
+            &stop,
+            |_| {},
+        );
+        assert!(result.best_move.is_some());
+        assert_eq!(result.nodes, 0);
+    }
+
+    #[test]
+    fn respects_node_limit() {
+        let result = run(
+            "6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1",
+            &Limits {
+                nodes: Some(64),
+                ..Limits::default()
+            },
+        );
+        assert_eq!(result.nodes, 64);
+    }
+
+    #[test]
+    fn centipawn_value_round_trip() {
+        for centipawns in [-500, -100, 0, 100, 500] {
+            assert_eq!(
+                centipawns_from_value(value_from_centipawns(centipawns)),
+                centipawns
+            );
+        }
+    }
 }

--- a/src/search/policy.rs
+++ b/src/search/policy.rs
@@ -1,6 +1,46 @@
-use super::tree;
-use crate::environment::Action;
+//! Action selection policy for the tree traversal phase of MCTS.
+//!
+//! Implements the [PUCT] (Polynomial Upper Confidence Trees) rule used by
+//! AlphaZero: children are selected by maximizing $Q(s, a) + U(s, a)$, where
+//! $U(s, a) = c_{puct} \cdot P(s, a) \cdot \frac{\sqrt{N(s)}}{1 + N(s, a)}$.
+//!
+//! [PUCT]: https://www.chessprogramming.org/UCT#PUCT
 
-fn select<A: Action>(node: &tree::Node<A>) {
-    todo!()
+use super::tree::{NodeId, Tree};
+
+/// Selects the most promising child of an expanded node according to the PUCT
+/// formula.
+///
+/// # Panics
+///
+/// Panics if the node has no children (the caller must only select from
+/// expanded, non-terminal nodes).
+pub(super) fn select_child(tree: &Tree, parent: NodeId, cpuct: f32) -> NodeId {
+    let parent_node = tree.node(parent);
+    debug_assert!(
+        !parent_node.children.is_empty(),
+        "can only select from expanded nodes"
+    );
+
+    let sqrt_parent_visits = (parent_node.visits.max(1) as f32).sqrt();
+
+    let mut best_child = parent_node.children[0];
+    let mut best_score = f32::NEG_INFINITY;
+
+    for &child_id in &parent_node.children {
+        let child = tree.node(child_id);
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "Q is in [-1, 1], truncation cannot happen"
+        )]
+        let exploitation = child.mean_value() as f32;
+        let exploration = cpuct * child.prior * sqrt_parent_visits / (1.0 + child.visits as f32);
+        let score = exploitation + exploration;
+        if score > best_score {
+            best_score = score;
+            best_child = child_id;
+        }
+    }
+
+    best_child
 }

--- a/src/search/tree.rs
+++ b/src/search/tree.rs
@@ -1,59 +1,90 @@
-use crate::environment::Action;
+//! Search tree structure for Monte Carlo Tree Search.
+//!
+//! The tree is stored as an arena ([`Tree`]) of [`Node`]s referencing their
+//! children by index. Each node stores the statistics of the *edge* leading
+//! into it (the action taken from its parent), following the AlphaZero
+//! convention: `visits` is $N(s, a)$, `total_value` is $W(s, a)$ and the mean
+//! value $Q(s, a)$ is valued from the perspective of the player to move at the
+//! parent node.
 
-/// Node stores (wins, draws, losses) statistics instead of expanded "value"
-/// (or total score), which is usually wins + 0.5 * draws.
-///
-/// For more details, ses https://lczero.org/blog/2020/04/wdl-head/
-// TODO: Measure the performance and see if switching to ArrayVec will make it
-// faster.
-pub(super) struct Node<A: Action> {
-    children: Vec<Node<A>>,
-    actions: Vec<A>,
-    prior: f32,
-    /// Total number of search iterations that went through this node.
-    visits: u32,
-    /// Number of wins from the perspective of player to move.
-    wins: u32,
-    /// Number of losses from the perspective of player to move.
-    losses: u32,
+use crate::chess::core::Move;
+
+/// Index of a node in the [`Tree`] arena.
+pub(super) type NodeId = u32;
+
+/// Index of the root node: the tree always contains the root at index 0.
+pub(super) const ROOT_ID: NodeId = 0;
+
+pub(super) struct Node {
+    /// The action that leads to this node. `None` only for the root.
+    pub(super) action: Option<Move>,
+    /// Arena indices of the children. Empty until the node is expanded.
+    pub(super) children: Vec<NodeId>,
+    /// Number of search iterations that went through this node.
+    pub(super) visits: u32,
+    /// Sum of backed-up values, from the perspective of the player to move at
+    /// the parent node.
+    pub(super) total_value: f64,
+    /// Prior probability of selecting this node's action from the parent.
+    pub(super) prior: f32,
+    /// Exact value of the node if it is terminal (checkmate, stalemate or a
+    /// draw by the rules), from the perspective of the player to move at this
+    /// node's position.
+    pub(super) terminal: Option<f64>,
+    /// Whether the node's children have been generated.
+    pub(super) expanded: bool,
 }
 
-impl<A: Action> Default for Node<A> {
-    fn default() -> Self {
+impl Node {
+    fn new(action: Option<Move>, prior: f32) -> Self {
         Self {
+            action,
             children: Vec::new(),
-            actions: Vec::new(),
-            prior: 0.0,
             visits: 0,
-            wins: 0,
-            losses: 0,
+            total_value: 0.0,
+            prior,
+            terminal: None,
+            expanded: false,
+        }
+    }
+
+    /// Mean action value $Q(s, a)$ from the perspective of the player to move
+    /// at the parent node. Unvisited nodes have a neutral value.
+    #[must_use]
+    pub(super) fn mean_value(&self) -> f64 {
+        if self.visits == 0 {
+            0.0
+        } else {
+            self.total_value / f64::from(self.visits)
         }
     }
 }
 
-impl<A: Action> Node<A> {
-    fn expand(&mut self) {
-        todo!()
+pub(super) struct Tree {
+    nodes: Vec<Node>,
+}
+
+impl Tree {
+    /// Creates a tree containing only an unexpanded root node.
+    pub(super) fn new() -> Self {
+        Self {
+            nodes: vec![Node::new(None, 1.0)],
+        }
     }
 
-    /// Returns true if the node has been visited at least once.
-    #[must_use]
-    const fn visited(&self) -> bool {
-        self.visits > 0
+    pub(super) fn node(&self, id: NodeId) -> &Node {
+        &self.nodes[id as usize]
     }
 
-    #[must_use]
-    const fn is_leaf(&self) -> bool {
-        todo!()
+    pub(super) fn node_mut(&mut self, id: NodeId) -> &mut Node {
+        &mut self.nodes[id as usize]
     }
 
-    #[must_use]
-    const fn is_terminal(&self) -> bool {
-        todo!()
-    }
-
-    #[must_use]
-    const fn draws(&self) -> u32 {
-        self.visits - self.wins - self.losses
+    /// Adds a child node for the given action and returns its id.
+    pub(super) fn add_child(&mut self, parent: NodeId, action: Move, prior: f32) -> NodeId {
+        let id = NodeId::try_from(self.nodes.len()).expect("search tree exceeded u32 capacity");
+        self.nodes.push(Node::new(Some(action), prior));
+        self.nodes[parent as usize].children.push(id);
+        id
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,5 @@
 use predicates::boolean::PredicateBooleanExt;
-use predicates::str::contains;
+use predicates::str::{contains, is_match};
 
 #[test]
 fn uci_setup() {
@@ -17,15 +17,90 @@ fn uci_setup() {
     );
 }
 
-// #[test]
-// #[ignore]
-// fn openbench_output() {
-//     let mut cmd = Command::cargo_bin(BINARY_NAME).expect("Binary should be
-// built");     let _ = cmd.arg("bench");
+#[test]
+fn uci_bestmove_with_node_limit() {
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
 
-//     drop(
-//         cmd.assert()
-//             .stdout(is_match(r"^\d+ nodes \d+ nps$").unwrap())
-//             .success(),
-//     );
-// }
+    drop(
+        cmd.write_stdin("uci\nisready\nposition startpos moves e2e4 e7e5\ngo nodes 500\nquit\n")
+            .assert()
+            .success()
+            .stdout(contains("readyok").and(is_match(r"bestmove [a-h][1-8][a-h][1-8]").unwrap())),
+    );
+}
+
+#[test]
+fn uci_finds_backrank_mate() {
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
+
+    drop(
+        cmd.write_stdin("position fen 6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1\ngo nodes 3000\nquit\n")
+            .assert()
+            .success()
+            .stdout(contains("bestmove a1a8")),
+    );
+}
+
+#[test]
+fn uci_stop_terminates_infinite_search() {
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
+
+    drop(
+        cmd.write_stdin("position startpos\ngo infinite\nstop\nquit\n")
+            .assert()
+            .success()
+            .stdout(is_match(r"bestmove [a-h][1-8][a-h][1-8]").unwrap()),
+    );
+}
+
+#[test]
+fn uci_go_movetime() {
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
+
+    drop(
+        cmd.write_stdin("position startpos\ngo movetime 100\nquit\n")
+            .assert()
+            .success()
+            .stdout(is_match(r"bestmove [a-h][1-8][a-h][1-8]").unwrap()),
+    );
+}
+
+#[test]
+fn uci_rejects_illegal_moves() {
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
+
+    drop(
+        cmd.write_stdin("position startpos moves e2e5\nquit\n")
+            .assert()
+            .success()
+            .stdout(contains("info string invalid position")),
+    );
+}
+
+#[test]
+fn uci_bestmove_none_when_no_legal_moves() {
+    // Black is checkmated; there is nothing to search.
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
+
+    drop(
+        cmd.write_stdin(
+            "position fen rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 4 3\ngo nodes \
+             10\nquit\n",
+        )
+        .assert()
+        .success()
+        .stdout(contains("bestmove (none)")),
+    );
+}
+
+#[test]
+fn openbench_output() {
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
+    let _ = cmd.arg("bench");
+
+    drop(
+        cmd.assert()
+            .success()
+            .stdout(is_match(r"(?m)^\d+ nodes \d+ nps$").unwrap()),
+    );
+}


### PR DESCRIPTION
## Summary

Turns pabi from a (perft-verified) move generator into a playing UCI engine, following up on #322. Implements the previously discussed steps 1–5: minimal playing engine, correctness infrastructure, MCTS skeleton + time manager, NN plumbing, and UCI feature completeness.

### Evaluation (`src/evaluation`)

- Tapered PeSTO evaluation in centipawns from the side-to-move perspective, consuming the tables `build.rs` already generated.
- **Fixed two latent bugs in the (previously unused) table generation**: the piece order was reversed relative to `PieceKind` (plane 0 was the king table while `Piece::plane()` maps pawn to 0, despite the comment claiming they match), and the White/Black square mirroring was inverted (White planes read the rank-8-first source tables unflipped). Covered by sign/symmetry/orientation tests.

### Search (`src/search`)

- AlphaZero-style MCTS replacing the `todo!()` stubs: arena tree with edge statistics (`tree.rs`), PUCT selection (`policy.rs`), and the search loop (`mcts.rs`) with evaluation-backed expansion (no rollouts), uniform priors until the policy network lands.
- Exact terminal handling: checkmate/stalemate, 50-move rule, insufficient material, and repetition draws checked against both the game history and the current search path (cacheable per node since tree paths are unique).
- Limits (nodes / movetime / infinite) + external stop flag; periodic UCI `info` lines with depth, nodes, nps, score cp and pv.
- Tests: finds a back-rank mate-in-1, respects node limits, terminates instantly on a pre-set stop flag, centipawn↔value round-trip.

### Engine (`src/engine`)

- `go` runs the search on a background thread and always prints `bestmove`; `stop` interrupts it. `quit` lets finite-limit searches finish (scripted/piped input still gets a meaningful bestmove) and interrupts infinite ones.
- Time manager: remaining-time/increment → per-move budget (~1/20 of remaining + inc/2, capped at half remaining, with move overhead margin).
- New `go` arguments parsed and handled: `movetime`, `nodes`, `infinite` (`depth` parsed but ignored by MCTS with an info notice).
- `setoption` handlers for Hash / Threads / SyzygyTablebase (stored + validated, advertised in the handshake); `state` debugging extension; OpenBench `bench` (~4s debug, prints `<nodes> nodes <nps> nps`).
- `position` now **validates every move against the legal move list** and maintains the game-history hashes used for repetition detection; invalid input produces an `info string` instead of state corruption or a dropped connection.

### NN plumbing

- `Move::policy_index()`: AlphaZero 64×73 policy action-space encoding (56 sliding planes, 8 knight planes, 9 underpromotion planes; queen promotions via sliding planes), wired into `environment::Action::get_index`. Encodes from the mover's perspective via the existing `flip_perspective`.
- `evaluation::features::Features`: input piece planes + castling/en-passant/halfmove scalars from the side-to-move perspective, orientation-matched to the action space.

### Correctness infrastructure

- New random-game test (100 seeded games × 200 plies) asserting the incrementally maintained Zobrist hash always equals `compute_hash()` from scratch and positions remain legal — guarding the hand-written hash updates (castling, en passant, promotions, captures) that a future transposition table will depend on.

## Testing

- 130 tests pass: 68 lib (14 new search/eval/features/encoding/time-manager suites), 47 chess integration, 8 UCI end-to-end integration tests driving the real binary (bestmove, mate finding, `stop`, `movetime`, illegal-move rejection, `bestmove (none)`, bench output format), 7 doctests.
- All 12 slow release-mode perft tests pass (95s).
- Self-play smoke test: the engine played a full 240-ply game against itself over real UCI without crashes, with every move legality-validated on re-entry.
- `cargo +nightly fmt --check` clean; clippy clean of denied lints (remaining warnings match patterns already present on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVrKvkMe4xDmkRAksacBzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVrKvkMe4xDmkRAksacBzk)_