### PR TITLE
Code-quality pass: deduplicate move-making/primitives and tighten lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,34 +68,37 @@ strip = true
 # TODO: Set profile-generate and profile-use (https://github.com/kirillbobyrev/pabi/issues/9).
 
 [lints.rust]
-# absolute_paths_not_starting_with_crate = "warn"
-# let_underscore_drop = "warn"
-# macro_use_extern_crate = "warn"
-# missing_docs = "warn"
-# unused_extern_crates = "warn"
-# unused_import_braces = "warn"
-# unused_lifetimes = "warn"
-# unused_qualifications = "warn"
+absolute_paths_not_starting_with_crate = "warn"
 keyword_idents_2018 = "deny"
 keyword_idents_2024 = "deny"
+macro_use_extern_crate = "warn"
 trivial_casts = "deny"
-# trivial_numeric_casts = "deny"
-# unreachable_pub = "deny"
+trivial_numeric_casts = "deny"
+unreachable_pub = "deny"
+unused_extern_crates = "warn"
+unused_import_braces = "warn"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+# TODO: Enable once the remaining public items are documented and the search
+# stubs stop discarding results.
+# let_underscore_drop = "warn"
+# missing_docs = "warn"
 # unused_results = "deny"
 
 [lints.clippy]
 missing_transmute_annotations = "allow"
-# cargo = "warn"
-# complexity = "warn"
-# correctness = "warn"
-# nursery = "warn"
-# pedantic = "warn"
-# style = "warn"
+# The core clippy groups. `perf` and `suspicious` are denied because a
+# regression there is almost always a real bug; the rest warn to keep iteration
+# friction low. `pedantic`/`nursery`/`cargo` are intentionally left off: they are
+# dominated by low-value style noise and transitive-dependency reports.
+correctness = { level = "deny", priority = -1 }
 suspicious = { level = "deny", priority = -1 }
-redundant_pattern_matching = "deny"
 perf = { level = "deny", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+style = { level = "warn", priority = -1 }
 allow_attributes_without_reason = "deny"
 derivable_impls = "deny"
+redundant_pattern_matching = "deny"
 
 [lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,8 @@
 # Some options here require nightly.
 edition = "2024"
+# Opt into the 2024 formatting style (import grouping, let-else, etc.) rather
+# than staying on the older default style rules.
+style_edition = "2024"
 format_code_in_doc_comments = true
 format_macro_matchers = true
 group_imports = "StdExternalCrate"

--- a/src/chess/bitboard.rs
+++ b/src/chess/bitboard.rs
@@ -19,7 +19,9 @@
 //! [BitboardCalculator]: https://gekomad.github.io/Cinnamon/BitboardCalculator/
 //! [PEXT Bitboards]: https://www.chessprogramming.org/BMI2#PEXTBitboards
 
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, Not, Shl, Shr, Sub, SubAssign};
+use std::ops::{
+    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr, Sub, SubAssign,
+};
 use std::{fmt, mem};
 
 use itertools::Itertools;
@@ -91,6 +93,11 @@ impl Bitboard {
     /// Clears given square from the set.
     pub(super) fn clear(&mut self, square: Square) {
         *self &= !Self::from(square);
+    }
+
+    /// Toggles given square: adds it if absent, removes it if present.
+    pub(super) fn toggle(&mut self, square: Square) {
+        *self ^= Self::from(square);
     }
 
     /// Returns true if this bitboard contains given square.
@@ -238,6 +245,12 @@ impl BitXor for Bitboard {
 
     fn bitxor(self, rhs: Self) -> Self::Output {
         Self::from_bits(self.bits.bitxor(rhs.bits))
+    }
+}
+
+impl BitXorAssign for Bitboard {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.bits.bitxor_assign(rhs.bits);
     }
 }
 

--- a/src/chess/core.rs
+++ b/src/chess/core.rs
@@ -538,6 +538,37 @@ pub enum PieceKind {
     King,
 }
 
+impl PieceKind {
+    /// Returns the lowercase [algebraic notation] letter for this piece kind.
+    ///
+    /// [algebraic notation]: https://www.chessprogramming.org/Algebraic_Chess_Notation
+    #[must_use]
+    pub(crate) const fn to_char(self) -> char {
+        match self {
+            Self::Pawn => 'p',
+            Self::Knight => 'n',
+            Self::Bishop => 'b',
+            Self::Rook => 'r',
+            Self::Queen => 'q',
+            Self::King => 'k',
+        }
+    }
+
+    /// Parses a piece kind from its lowercase algebraic notation letter.
+    #[must_use]
+    pub(crate) const fn from_char(symbol: char) -> Option<Self> {
+        Some(match symbol {
+            'p' => Self::Pawn,
+            'n' => Self::Knight,
+            'b' => Self::Bishop,
+            'r' => Self::Rook,
+            'q' => Self::Queen,
+            'k' => Self::King,
+            _ => return None,
+        })
+    }
+}
+
 impl From<Promotion> for PieceKind {
     fn from(promotion: Promotion) -> Self {
         match promotion {
@@ -551,18 +582,12 @@ impl From<Promotion> for PieceKind {
 
 impl fmt::Display for PieceKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_char(match &self {
-            Self::Pawn => 'p',
-            Self::Knight => 'n',
-            Self::Bishop => 'b',
-            Self::Rook => 'r',
-            Self::Queen => 'q',
-            Self::King => 'k',
-        })
+        f.write_char(self.to_char())
     }
 }
 
 /// Represents a specific piece owned by a player.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Piece {
     #[allow(missing_docs, reason = "Enum variants are self-explanatory")]
     pub player: Player,
@@ -580,78 +605,28 @@ impl Piece {
 impl TryFrom<char> for Piece {
     type Error = anyhow::Error;
 
+    /// Parses a piece from its algebraic notation letter: uppercase for White,
+    /// lowercase for Black.
     fn try_from(symbol: char) -> anyhow::Result<Self> {
-        match symbol {
-            'P' => Ok(Self {
-                player: Player::White,
-                kind: PieceKind::Pawn,
-            }),
-            'N' => Ok(Self {
-                player: Player::White,
-                kind: PieceKind::Knight,
-            }),
-            'B' => Ok(Self {
-                player: Player::White,
-                kind: PieceKind::Bishop,
-            }),
-            'R' => Ok(Self {
-                player: Player::White,
-                kind: PieceKind::Rook,
-            }),
-            'Q' => Ok(Self {
-                player: Player::White,
-                kind: PieceKind::Queen,
-            }),
-            'K' => Ok(Self {
-                player: Player::White,
-                kind: PieceKind::King,
-            }),
-            'p' => Ok(Self {
-                player: Player::Black,
-                kind: PieceKind::Pawn,
-            }),
-            'n' => Ok(Self {
-                player: Player::Black,
-                kind: PieceKind::Knight,
-            }),
-            'b' => Ok(Self {
-                player: Player::Black,
-                kind: PieceKind::Bishop,
-            }),
-            'r' => Ok(Self {
-                player: Player::Black,
-                kind: PieceKind::Rook,
-            }),
-            'k' => Ok(Self {
-                player: Player::Black,
-                kind: PieceKind::King,
-            }),
-            'q' => Ok(Self {
-                player: Player::Black,
-                kind: PieceKind::Queen,
-            }),
-            _ => bail!("piece symbol should be in \"PNBRQKpnbrqk\", got '{symbol}'"),
-        }
+        let Some(kind) = PieceKind::from_char(symbol.to_ascii_lowercase()) else {
+            bail!("piece symbol should be in \"PNBRQKpnbrqk\", got '{symbol}'");
+        };
+        let player = if symbol.is_ascii_uppercase() {
+            Player::White
+        } else {
+            Player::Black
+        };
+        Ok(Self { player, kind })
     }
 }
 
 impl fmt::Display for Piece {
+    /// Uppercase letter for White pieces, lowercase for Black.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_char(match (&self.player, &self.kind) {
-            // White: uppercase symbols.
-            (Player::White, PieceKind::Pawn) => 'P',
-            (Player::White, PieceKind::Knight) => 'N',
-            (Player::White, PieceKind::Bishop) => 'B',
-            (Player::White, PieceKind::Rook) => 'R',
-            (Player::White, PieceKind::Queen) => 'Q',
-            (Player::White, PieceKind::King) => 'K',
-            // Black: lowercase symbols.
-            (Player::Black, PieceKind::Pawn) => 'p',
-            (Player::Black, PieceKind::Knight) => 'n',
-            (Player::Black, PieceKind::Bishop) => 'b',
-            (Player::Black, PieceKind::Rook) => 'r',
-            (Player::Black, PieceKind::Queen) => 'q',
-            (Player::Black, PieceKind::King) => 'k',
+        let symbol = self.kind.to_char();
+        f.write_char(match self.player {
+            Player::White => symbol.to_ascii_uppercase(),
+            Player::Black => symbol,
         })
     }
 }

--- a/src/chess/position.rs
+++ b/src/chess/position.rs
@@ -290,17 +290,13 @@ impl Position {
                     }
                     _ => (),
                 }
-                match Piece::try_from(symbol) {
-                    Ok(piece) => {
-                        let pieces = match piece.player {
-                            Player::White => &mut white_pieces,
-                            Player::Black => &mut black_pieces,
-                        };
-                        let square = Square::new(file.try_into()?, rank);
-                        *pieces.bitboard_for_mut(piece.kind) |= Bitboard::from(square);
-                    }
-                    Err(e) => return Err(e),
-                }
+                let piece = Piece::try_from(symbol)?;
+                let pieces = match piece.player {
+                    Player::White => &mut white_pieces,
+                    Player::Black => &mut black_pieces,
+                };
+                let square = Square::new(file.try_into()?, rank);
+                *pieces.bitboard_for_mut(piece.kind) |= Bitboard::from(square);
                 file += 1;
             }
             if file != BOARD_WIDTH {

--- a/src/chess/position.rs
+++ b/src/chess/position.rs
@@ -172,6 +172,13 @@ impl Position {
         }
     }
 
+    fn pieces_mut(&mut self, player: Player) -> &mut Pieces {
+        match player {
+            Player::White => &mut self.white_pieces,
+            Player::Black => &mut self.black_pieces,
+        }
+    }
+
     /// Returns Zobrist hash of the position.
     #[must_use]
     pub fn hash(&self) -> zobrist::Key {
@@ -493,216 +500,179 @@ impl Position {
     pub fn make_move(&mut self, next_move: &Move) {
         debug_assert!(self.is_legal());
 
-        // Increment halfmove clock early: it will be reset on capture or pawn
-        // push. Saturate to avoid overflow in (unadjudicated) games that go on
-        // long past the 50-move rule threshold.
+        let us = self.side_to_move;
+        let (from, to) = (next_move.from(), next_move.to());
+        let moved = self
+            .pieces(us)
+            .at(from)
+            .expect("a legal move originates from an occupied square");
+
+        // Increment the halfmove clock early: captures and pawn moves reset it
+        // below. Saturate to avoid overflow in (unadjudicated) games that run
+        // long past the 50-move threshold.
         self.halfmove_clock = self.halfmove_clock.saturating_add(1);
 
-        // En passant is always transient (lasts one move). Clear it from both
-        // the position state and the hash, saving the old value for capture
-        // detection in make_pawn_move().
+        // En passant is transient (lasts one move): clear it from the state and
+        // the hash, remembering the square to detect an en passant capture.
         let previous_en_passant = self.en_passant_square.take();
         if let Some(ep_square) = previous_en_passant {
             self.hash ^= generated::EN_PASSANT_FILES[ep_square.file() as usize];
         }
 
         self.update_castling_rights(next_move);
+        self.remove_captured_piece(to);
 
-        self.handle_capture(next_move);
-        self.make_pawn_move(next_move, previous_en_passant);
-        self.make_king_move(next_move);
-        self.make_regular_move(next_move);
-
-        if self.side_to_move == Player::Black {
-            self.fullmove_counter += 1;
+        match moved {
+            PieceKind::Pawn => {
+                self.make_pawn_move(from, to, next_move.promotion(), previous_en_passant)
+            }
+            PieceKind::King => self.make_king_move(from, to),
+            kind => self.move_piece(Piece { player: us, kind }, from, to),
         }
 
-        self.side_to_move = !self.side_to_move;
+        if us == Player::Black {
+            self.fullmove_counter += 1;
+        }
+        self.side_to_move = !us;
         self.hash ^= generated::BLACK_TO_MOVE;
     }
 
+    /// Adds `piece` to `square` if it is absent or removes it if present,
+    /// keeping the Zobrist hash in sync. Because keys are XOR-ed in, the same
+    /// call also undoes itself.
+    fn toggle_piece(&mut self, piece: Piece, square: Square) {
+        self.pieces_mut(piece.player)
+            .bitboard_for_mut(piece.kind)
+            .toggle(square);
+        self.hash ^= generated::get_piece_key(piece, square);
+    }
+
+    /// Moves `piece` between two squares, keeping the hash in sync.
+    fn move_piece(&mut self, piece: Piece, from: Square, to: Square) {
+        self.toggle_piece(piece, from);
+        self.toggle_piece(piece, to);
+    }
+
     fn update_castling_rights(&mut self, next_move: &Move) {
-        // Update white castling rights
         self.update_side_castling_rights(Player::White, next_move);
-        // Update black castling rights
         self.update_side_castling_rights(Player::Black, next_move);
     }
 
     fn update_side_castling_rights(&mut self, player: Player, next_move: &Move) {
-        let (king_square, kingside_rook, queenside_rook) = match player {
-            Player::White => (Square::E1, Square::H1, Square::A1),
-            Player::Black => (Square::E8, Square::H8, Square::A8),
-        };
-
-        let (kingside_right, queenside_right) = match player {
-            Player::White => (CastleRights::WHITE_SHORT, CastleRights::WHITE_LONG),
-            Player::Black => (CastleRights::BLACK_SHORT, CastleRights::BLACK_LONG),
-        };
-
-        let (kingside_hash, queenside_hash) = match player {
+        let (king, short_rook, long_rook, short, long, short_key, long_key) = match player {
             Player::White => (
+                Square::E1,
+                Square::H1,
+                Square::A1,
+                CastleRights::WHITE_SHORT,
+                CastleRights::WHITE_LONG,
                 generated::WHITE_CAN_CASTLE_SHORT,
                 generated::WHITE_CAN_CASTLE_LONG,
             ),
             Player::Black => (
+                Square::E8,
+                Square::H8,
+                Square::A8,
+                CastleRights::BLACK_SHORT,
+                CastleRights::BLACK_LONG,
                 generated::BLACK_CAN_CASTLE_SHORT,
                 generated::BLACK_CAN_CASTLE_LONG,
             ),
         };
 
-        // Check if king or rook moved
-        if self.castling.contains(kingside_right)
-            && (next_move.from() == king_square
-                || next_move.from() == kingside_rook
-                || next_move.to() == kingside_rook)
-        {
-            self.castling.remove(kingside_right);
-            self.hash ^= kingside_hash;
-        }
-
-        if self.castling.contains(queenside_right)
-            && (next_move.from() == king_square
-                || next_move.from() == queenside_rook
-                || next_move.to() == queenside_rook)
-        {
-            self.castling.remove(queenside_right);
-            self.hash ^= queenside_hash;
-        }
-    }
-
-    fn handle_capture(&mut self, next_move: &Move) {
-        let their_pieces = match self.side_to_move {
-            Player::White => &mut self.black_pieces,
-            Player::Black => &mut self.white_pieces,
-        };
-
-        if their_pieces.all().contains(next_move.to()) {
-            // Capturing a piece resets the clock.
-            self.halfmove_clock = 0;
-
-            let square = next_move.to();
-
-            for (piece, kind) in [
-                (&mut their_pieces.queens, PieceKind::Queen),
-                (&mut their_pieces.rooks, PieceKind::Rook),
-                (&mut their_pieces.bishops, PieceKind::Bishop),
-                (&mut their_pieces.knights, PieceKind::Knight),
-                (&mut their_pieces.pawns, PieceKind::Pawn),
-            ] {
-                if piece.contains(square) {
-                    piece.clear(square);
-                    self.hash ^= generated::get_piece_key(
-                        Piece {
-                            player: !self.side_to_move,
-                            kind,
-                        },
-                        square,
-                    );
-                    break;
-                }
+        // A castling right is lost when the king or the corresponding rook
+        // leaves its square, or when that rook is captured on its square.
+        for (right, rook, key) in [(short, short_rook, short_key), (long, long_rook, long_key)] {
+            if self.castling.contains(right)
+                && (next_move.from() == king || next_move.from() == rook || next_move.to() == rook)
+            {
+                self.castling.remove(right);
+                self.hash ^= key;
             }
         }
     }
 
-    fn make_pawn_move(&mut self, next_move: &Move, previous_en_passant: Option<Square>) -> bool {
-        let (our_pieces, their_pieces) = match self.side_to_move {
-            Player::White => (&mut self.white_pieces, &mut self.black_pieces),
-            Player::Black => (&mut self.black_pieces, &mut self.white_pieces),
-        };
-
-        if !our_pieces.pawns.contains(next_move.from()) {
-            return false;
+    /// Removes the opponent's piece captured on `square` (if any) and resets
+    /// the halfmove clock. En passant captures do not land on the captured
+    /// pawn's square and are handled in [`Self::make_pawn_move`].
+    fn remove_captured_piece(&mut self, square: Square) {
+        let them = !self.side_to_move;
+        if let Some(kind) = self.pieces(them).at(square) {
+            self.halfmove_clock = 0;
+            self.toggle_piece(Piece { player: them, kind }, square);
         }
-
-        // Pawn move resets the 50 halfmove rule clock.
-        self.halfmove_clock = 0;
-
-        // Check en passant.
-        if let Some(en_passant_square) = previous_en_passant
-            && next_move.to() == en_passant_square
-        {
-            let captured_pawn = Square::new(next_move.to().file(), next_move.from().rank());
-            their_pieces.pawns.clear(captured_pawn);
-            self.hash ^= generated::get_piece_key(
-                Piece {
-                    player: !self.side_to_move,
-                    kind: PieceKind::Pawn,
-                },
-                captured_pawn,
-            );
-        }
-
-        our_pieces.pawns.clear(next_move.from());
-        self.hash ^= generated::get_piece_key(
-            Piece {
-                player: self.side_to_move,
-                kind: PieceKind::Pawn,
-            },
-            next_move.from(),
-        );
-
-        if let Some(promotion) = next_move.promotion() {
-            let kind = PieceKind::from(promotion);
-            our_pieces.bitboard_for_mut(kind).extend(next_move.to());
-            self.hash ^= generated::get_piece_key(
-                Piece {
-                    player: self.side_to_move,
-                    kind,
-                },
-                next_move.to(),
-            );
-            return true;
-        }
-
-        our_pieces.pawns.extend(next_move.to());
-        self.hash ^= generated::get_piece_key(
-            Piece {
-                player: self.side_to_move,
-                kind: PieceKind::Pawn,
-            },
-            next_move.to(),
-        );
-
-        let single_push_square = next_move
-            .from()
-            .shift(pawn_push_direction(self.side_to_move))
-            .unwrap();
-
-        // Double push creates en passant square.
-        if next_move.from().rank() == Rank::pawns_starting(self.side_to_move)
-                && next_move.from().file() == next_move.to().file()
-                && single_push_square != next_move.to()
-                // Technically, this is not correct: https://github.com/jhlywa/chess.js/issues/294
-                && (their_pieces.pawns & attacks::pawn_attacks(single_push_square, self.side_to_move)).has_any()
-        {
-            self.en_passant_square = Some(single_push_square);
-            self.hash ^= generated::EN_PASSANT_FILES[single_push_square.file() as usize];
-        }
-
-        true
     }
 
-    /// Castle or regular king move.
-    fn make_king_move(&mut self, next_move: &Move) -> bool {
-        // Check castling conditions before borrowing pieces
-        let is_castling = next_move.from().rank() == Rank::backrank(self.side_to_move)
-            && next_move.to().rank() == Rank::backrank(self.side_to_move)
-            && next_move.from().file() == File::E
-            && (next_move.to().file() == File::G || next_move.to().file() == File::C);
+    fn make_pawn_move(
+        &mut self,
+        from: Square,
+        to: Square,
+        promotion: Option<Promotion>,
+        previous_en_passant: Option<Square>,
+    ) {
+        let us = self.side_to_move;
+        // Any pawn move resets the halfmove clock.
+        self.halfmove_clock = 0;
 
-        let our_pieces = match self.side_to_move {
-            Player::White => &mut self.white_pieces,
-            Player::Black => &mut self.black_pieces,
-        };
-
-        if !our_pieces.king.contains(next_move.from()) {
-            return false;
+        // A pawn landing on the en passant square captures the pawn that
+        // double-pushed on the previous move (which sits beside the target).
+        if previous_en_passant == Some(to) {
+            let captured = Square::new(to.file(), from.rank());
+            self.toggle_piece(
+                Piece {
+                    player: !us,
+                    kind: PieceKind::Pawn,
+                },
+                captured,
+            );
         }
 
-        // Handle castling moves
-        if is_castling {
-            let backrank = Rank::backrank(self.side_to_move);
-            let (rook_from, rook_to) = if next_move.to().file() == File::G {
+        self.toggle_piece(
+            Piece {
+                player: us,
+                kind: PieceKind::Pawn,
+            },
+            from,
+        );
+        if let Some(promotion) = promotion {
+            self.toggle_piece(
+                Piece {
+                    player: us,
+                    kind: promotion.into(),
+                },
+                to,
+            );
+            return;
+        }
+        self.toggle_piece(
+            Piece {
+                player: us,
+                kind: PieceKind::Pawn,
+            },
+            to,
+        );
+
+        // A double push that an enemy pawn could answer sets the en passant
+        // square.
+        let single_push = from.shift(pawn_push_direction(us)).unwrap();
+        if from.rank() == Rank::pawns_starting(us)
+            && from.file() == to.file()
+            && single_push != to
+            // Technically not fully correct: https://github.com/jhlywa/chess.js/issues/294
+            && (self.pieces(!us).pawns & attacks::pawn_attacks(single_push, us)).has_any()
+        {
+            self.en_passant_square = Some(single_push);
+            self.hash ^= generated::EN_PASSANT_FILES[single_push.file() as usize];
+        }
+    }
+
+    fn make_king_move(&mut self, from: Square, to: Square) {
+        let us = self.side_to_move;
+        // A king stepping two files (E to G or C) is castling: move the rook to
+        // the square the king skipped over.
+        if from.file() == File::E && matches!(to.file(), File::G | File::C) {
+            let backrank = Rank::backrank(us);
+            let (rook_from, rook_to) = if to.file() == File::G {
                 (
                     Square::new(File::H, backrank),
                     Square::new(File::F, backrank),
@@ -713,79 +683,23 @@ impl Position {
                     Square::new(File::D, backrank),
                 )
             };
-
-            // Move the rook
-            our_pieces.rooks.clear(rook_from);
-            self.hash ^= generated::get_piece_key(
+            self.move_piece(
                 Piece {
-                    player: self.side_to_move,
+                    player: us,
                     kind: PieceKind::Rook,
                 },
                 rook_from,
-            );
-            our_pieces.rooks.extend(rook_to);
-            self.hash ^= generated::get_piece_key(
-                Piece {
-                    player: self.side_to_move,
-                    kind: PieceKind::Rook,
-                },
                 rook_to,
             );
         }
-
-        // Move the king
-        our_pieces.king.clear(next_move.from());
-        self.hash ^= generated::get_piece_key(
+        self.move_piece(
             Piece {
-                player: self.side_to_move,
+                player: us,
                 kind: PieceKind::King,
             },
-            next_move.from(),
+            from,
+            to,
         );
-        our_pieces.king.extend(next_move.to());
-        self.hash ^= generated::get_piece_key(
-            Piece {
-                player: self.side_to_move,
-                kind: PieceKind::King,
-            },
-            next_move.to(),
-        );
-
-        true
-    }
-
-    fn make_regular_move(&mut self, next_move: &Move) {
-        let our_pieces = match self.side_to_move {
-            Player::White => &mut self.white_pieces,
-            Player::Black => &mut self.black_pieces,
-        };
-
-        for (bitboard, kind) in [
-            (&mut our_pieces.queens, PieceKind::Queen),
-            (&mut our_pieces.rooks, PieceKind::Rook),
-            (&mut our_pieces.bishops, PieceKind::Bishop),
-            (&mut our_pieces.knights, PieceKind::Knight),
-        ] {
-            if bitboard.contains(next_move.from()) {
-                bitboard.clear(next_move.from());
-                self.hash ^= generated::get_piece_key(
-                    Piece {
-                        player: self.side_to_move,
-                        kind,
-                    },
-                    next_move.from(),
-                );
-                bitboard.extend(next_move.to());
-                self.hash ^= generated::get_piece_key(
-                    Piece {
-                        player: self.side_to_move,
-                        kind,
-                    },
-                    next_move.to(),
-                );
-                return;
-            }
-        }
     }
 
     #[must_use]
@@ -1302,6 +1216,59 @@ fn is_discovered_check_after_en_passant(
         || (attacks::bishop_attacks(king, occupancy) & their_pieces.bishops).has_any()
 }
 
+/// Static geometry of a single castling move.
+struct Castle {
+    right: CastleRights,
+    /// Squares the king passes over, including its destination; none of them
+    /// may be attacked.
+    king_walk: Bitboard,
+    /// Squares between the king and the rook; all of them must be empty.
+    rook_walk: Bitboard,
+    king_from: Square,
+    king_to: Square,
+}
+
+impl Castle {
+    /// The two castling moves available to each player, kingside then
+    /// queenside.
+    const fn for_player(player: Player) -> &'static [Self; 2] {
+        match player {
+            Player::White => &[
+                Self {
+                    right: CastleRights::WHITE_SHORT,
+                    king_walk: attacks::WHITE_SHORT_CASTLE_KING_WALK,
+                    rook_walk: attacks::WHITE_SHORT_CASTLE_ROOK_WALK,
+                    king_from: Square::E1,
+                    king_to: Square::G1,
+                },
+                Self {
+                    right: CastleRights::WHITE_LONG,
+                    king_walk: attacks::WHITE_LONG_CASTLE_KING_WALK,
+                    rook_walk: attacks::WHITE_LONG_CASTLE_ROOK_WALK,
+                    king_from: Square::E1,
+                    king_to: Square::C1,
+                },
+            ],
+            Player::Black => &[
+                Self {
+                    right: CastleRights::BLACK_SHORT,
+                    king_walk: attacks::BLACK_SHORT_CASTLE_KING_WALK,
+                    rook_walk: attacks::BLACK_SHORT_CASTLE_ROOK_WALK,
+                    king_from: Square::E8,
+                    king_to: Square::G8,
+                },
+                Self {
+                    right: CastleRights::BLACK_LONG,
+                    king_walk: attacks::BLACK_LONG_CASTLE_KING_WALK,
+                    rook_walk: attacks::BLACK_LONG_CASTLE_ROOK_WALK,
+                    king_from: Square::E8,
+                    king_to: Square::C8,
+                },
+            ],
+        }
+    }
+}
+
 fn generate_castle_moves(
     us: Player,
     checkers: Bitboard,
@@ -1310,86 +1277,17 @@ fn generate_castle_moves(
     occupied_squares: Bitboard,
     moves: &mut MoveList,
 ) {
-    if !checkers.is_empty() {
+    if checkers.has_any() {
         return;
     }
-
-    let (
-        king_sq,
-        short_right,
-        long_right,
-        short_king_walk,
-        short_rook_walk,
-        long_king_walk,
-        long_rook_walk,
-        short_to,
-        long_to,
-    ) = match us {
-        Player::White => (
-            Square::E1,
-            CastleRights::WHITE_SHORT,
-            CastleRights::WHITE_LONG,
-            attacks::WHITE_SHORT_CASTLE_KING_WALK,
-            attacks::WHITE_SHORT_CASTLE_ROOK_WALK,
-            attacks::WHITE_LONG_CASTLE_KING_WALK,
-            attacks::WHITE_LONG_CASTLE_ROOK_WALK,
-            Square::G1,
-            Square::C1,
-        ),
-        Player::Black => (
-            Square::E8,
-            CastleRights::BLACK_SHORT,
-            CastleRights::BLACK_LONG,
-            attacks::BLACK_SHORT_CASTLE_KING_WALK,
-            attacks::BLACK_SHORT_CASTLE_ROOK_WALK,
-            attacks::BLACK_LONG_CASTLE_KING_WALK,
-            attacks::BLACK_LONG_CASTLE_ROOK_WALK,
-            Square::G8,
-            Square::C8,
-        ),
-    };
-
-    try_castle(
-        castling,
-        short_right,
-        attacks,
-        short_king_walk,
-        short_rook_walk,
-        occupied_squares,
-        king_sq,
-        short_to,
-        moves,
-    );
-    try_castle(
-        castling,
-        long_right,
-        attacks,
-        long_king_walk,
-        long_rook_walk,
-        occupied_squares,
-        king_sq,
-        long_to,
-        moves,
-    );
-}
-
-fn try_castle(
-    castling: CastleRights,
-    right: CastleRights,
-    attacks: Bitboard,
-    king_walk: Bitboard,
-    rook_walk: Bitboard,
-    occupied_squares: Bitboard,
-    from: Square,
-    to: Square,
-    moves: &mut MoveList,
-) {
-    if castling.contains(right)
-        && (attacks & king_walk).is_empty()
-        && (occupied_squares & (king_walk | rook_walk)).is_empty()
-    {
-        unsafe {
-            moves.push_unchecked(Move::new(from, to, None));
+    for castle in Castle::for_player(us) {
+        if castling.contains(castle.right)
+            && (attacks & castle.king_walk).is_empty()
+            && (occupied_squares & (castle.king_walk | castle.rook_walk)).is_empty()
+        {
+            unsafe {
+                moves.push_unchecked(Move::new(castle.king_from, castle.king_to, None));
+            }
         }
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crate::chess::core::Move;
 use crate::chess::position::Position;
@@ -115,23 +115,14 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
                     }
                 }
                 Command::NewGame => self.new_game(),
-                Command::Go {
-                    wtime,
-                    btime,
-                    winc,
-                    binc,
-                    movetime,
-                    depth,
-                    nodes,
-                    infinite,
-                } => {
-                    if depth.is_some() {
+                Command::Go(go) => {
+                    if go.depth.is_some() {
                         self.send(
                             "info string depth limit is not supported by the MCTS search and is \
                              ignored",
                         )?;
                     }
-                    self.go(wtime, btime, winc, binc, movetime, nodes, infinite);
+                    self.go(&go);
                 }
                 Command::Stop => self.stop_search(),
                 Command::Quit => {
@@ -247,42 +238,36 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
         Ok(())
     }
 
-    /// Starts the search in a background thread. The thread reports progress
-    /// through `info` lines and always finishes by printing `bestmove`.
-    fn go(
-        &mut self,
-        wtime: Option<Duration>,
-        btime: Option<Duration>,
-        winc: Option<Duration>,
-        binc: Option<Duration>,
-        movetime: Option<Duration>,
-        nodes: Option<u64>,
-        infinite: bool,
-    ) {
-        self.stop_search();
-
+    /// Translates a `go` command into concrete [`mcts::Limits`]. An explicit
+    /// move time or `infinite` flag is used directly; otherwise a budget is
+    /// derived from the clock of the side to move, falling back to an infinite
+    /// search when no limit is given at all.
+    fn limits(&self, go: &uci::Go) -> mcts::Limits {
         let mut limits = mcts::Limits {
-            move_time: movetime,
-            nodes,
-            infinite,
+            move_time: go.movetime,
+            nodes: go.nodes,
+            infinite: go.infinite,
         };
-        if limits.move_time.is_none() && !infinite {
+        if limits.move_time.is_none() && !limits.infinite {
             let (time, increment) = match self.position.us() {
-                Player::White => (wtime, winc),
-                Player::Black => (btime, binc),
+                Player::White => (go.wtime, go.winc),
+                Player::Black => (go.btime, go.binc),
             };
-            if let Some(time) = time {
-                limits.move_time = Some(time_manager::time_budget(
-                    time,
-                    increment.unwrap_or_default(),
-                ));
-            }
+            limits.move_time =
+                time.map(|time| time_manager::time_budget(time, increment.unwrap_or_default()));
         }
-        // `go` without any limits means searching until told to stop.
         if limits.move_time.is_none() && limits.nodes.is_none() {
             limits.infinite = true;
         }
+        limits
+    }
 
+    /// Starts the search in a background thread. The thread reports progress
+    /// through `info` lines and always finishes by printing `bestmove`.
+    fn go(&mut self, go: &uci::Go) {
+        self.stop_search();
+
+        let limits = self.limits(go);
         let infinite = limits.infinite;
         let stop = Arc::new(AtomicBool::new(false));
         let position = self.position.clone();
@@ -296,15 +281,11 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
                 let _ = writeln!(out, "{info}");
                 let _ = out.flush();
             });
+            let best_move = result
+                .best_move
+                .map_or_else(|| "(none)".to_string(), |best_move| best_move.to_string());
             let mut out = out.lock().expect("output lock poisoned");
-            match result.best_move {
-                Some(best_move) => {
-                    let _ = writeln!(out, "bestmove {best_move}");
-                }
-                None => {
-                    let _ = writeln!(out, "bestmove (none)");
-                }
-            }
+            let _ = writeln!(out, "bestmove {best_move}");
             let _ = out.flush();
         });
 

--- a/src/engine/uci.rs
+++ b/src/engine/uci.rs
@@ -16,16 +16,7 @@ pub(super) enum Command {
         moves: Vec<String>,
     },
     NewGame,
-    Go {
-        wtime: Option<Duration>,
-        btime: Option<Duration>,
-        winc: Option<Duration>,
-        binc: Option<Duration>,
-        movetime: Option<Duration>,
-        depth: Option<u32>,
-        nodes: Option<u64>,
-        infinite: bool,
-    },
+    Go(Go),
     Stop,
     Quit,
     /// This is an extension to the UCI protocol useful for debugging. The
@@ -34,6 +25,20 @@ pub(super) enum Command {
     /// transposition table information and so on).
     State,
     Unknown(String),
+}
+
+/// Parsed arguments of the UCI `go` command. Every limit is optional; an empty
+/// `Go` means "search until stopped".
+#[derive(Debug, Default, PartialEq)]
+pub(super) struct Go {
+    pub(super) wtime: Option<Duration>,
+    pub(super) btime: Option<Duration>,
+    pub(super) winc: Option<Duration>,
+    pub(super) binc: Option<Duration>,
+    pub(super) movetime: Option<Duration>,
+    pub(super) depth: Option<u32>,
+    pub(super) nodes: Option<u64>,
+    pub(super) infinite: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -50,69 +55,38 @@ pub(super) enum OptionValue {
 }
 
 fn parse_go(parts: &[&str]) -> Command {
-    let mut wtime = None;
-    let mut btime = None;
-    let mut winc = None;
-    let mut binc = None;
-    let mut movetime = None;
-    let mut depth = None;
-    let mut nodes = None;
-    let mut infinite = false;
+    let mut go = Go::default();
+    // Time controls are given in milliseconds, as per the UCI protocol.
+    let millis = |value: &str| value.parse().map(Duration::from_millis).ok();
 
     let mut i = 1;
-
-    // Time controls are given in milliseconds, as per the UCI protocol.
     while i < parts.len() {
+        let value = parts.get(i + 1).copied();
         match parts[i] {
-            "wtime" if i + 1 < parts.len() => {
-                wtime = parts[i + 1].parse().map(Duration::from_millis).ok();
-                i += 2;
-            }
-            "btime" if i + 1 < parts.len() => {
-                btime = parts[i + 1].parse().map(Duration::from_millis).ok();
-                i += 2;
-            }
-            "winc" if i + 1 < parts.len() => {
-                winc = parts[i + 1].parse().map(Duration::from_millis).ok();
-                i += 2;
-            }
-            "binc" if i + 1 < parts.len() => {
-                binc = parts[i + 1].parse().map(Duration::from_millis).ok();
-                i += 2;
-            }
-            "movetime" if i + 1 < parts.len() => {
-                movetime = parts[i + 1].parse().map(Duration::from_millis).ok();
-                i += 2;
-            }
-            "depth" if i + 1 < parts.len() => {
-                depth = parts[i + 1].parse().ok();
-                i += 2;
-            }
-            "nodes" if i + 1 < parts.len() => {
-                nodes = parts[i + 1].parse().ok();
-                i += 2;
-            }
+            "wtime" => go.wtime = value.and_then(millis),
+            "btime" => go.btime = value.and_then(millis),
+            "winc" => go.winc = value.and_then(millis),
+            "binc" => go.binc = value.and_then(millis),
+            "movetime" => go.movetime = value.and_then(millis),
+            "depth" => go.depth = value.and_then(|value| value.parse().ok()),
+            "nodes" => go.nodes = value.and_then(|value| value.parse().ok()),
             "infinite" => {
-                infinite = true;
+                go.infinite = true;
                 i += 1;
+                continue;
             }
             // Tokens without a value (e.g. "ponder") and unsupported ones are
-            // skipped one at a time so that they can not swallow a keyword
-            // that follows them.
-            _ => i += 1,
+            // skipped one at a time so that they can not swallow a keyword that
+            // follows them.
+            _ => {
+                i += 1;
+                continue;
+            }
         }
+        i += 2;
     }
 
-    Command::Go {
-        wtime,
-        btime,
-        winc,
-        binc,
-        movetime,
-        depth,
-        nodes,
-        infinite,
-    }
+    Command::Go(go)
 }
 
 fn parse_setoption(parts: &[&str]) -> Command {
@@ -275,46 +249,32 @@ mod tests {
     fn parse_go() {
         assert_eq!(
             Command::parse("go wtime 300000 btime 300000 winc 10000 binc 10000"),
-            Command::Go {
+            Command::Go(Go {
                 wtime: Some(Duration::from_millis(300_000)),
                 btime: Some(Duration::from_millis(300_000)),
                 winc: Some(Duration::from_millis(10000)),
                 binc: Some(Duration::from_millis(10000)),
-                movetime: None,
-                depth: None,
-                nodes: None,
-                infinite: false,
-            }
+                ..Go::default()
+            })
         );
 
         assert_eq!(
             Command::parse("go wtime 1000"),
-            Command::Go {
+            Command::Go(Go {
                 wtime: Some(Duration::from_millis(1000)),
-                btime: None,
-                winc: None,
-                binc: None,
-                movetime: None,
-                depth: None,
-                nodes: None,
-                infinite: false,
-            }
+                ..Go::default()
+            })
         );
 
         // "infinite" and "ponder" have no value: the keywords that follow them
         // should still be picked up.
         assert_eq!(
             Command::parse("go ponder wtime 1000 btime 2000"),
-            Command::Go {
+            Command::Go(Go {
                 wtime: Some(Duration::from_millis(1000)),
                 btime: Some(Duration::from_millis(2000)),
-                winc: None,
-                binc: None,
-                movetime: None,
-                depth: None,
-                nodes: None,
-                infinite: false,
-            }
+                ..Go::default()
+            })
         );
     }
 
@@ -345,42 +305,25 @@ mod tests {
     fn parse_go_limits() {
         assert_eq!(
             Command::parse("go movetime 5000"),
-            Command::Go {
-                wtime: None,
-                btime: None,
-                winc: None,
-                binc: None,
+            Command::Go(Go {
                 movetime: Some(Duration::from_millis(5000)),
-                depth: None,
-                nodes: None,
-                infinite: false,
-            }
+                ..Go::default()
+            })
         );
         assert_eq!(
             Command::parse("go depth 12 nodes 100000"),
-            Command::Go {
-                wtime: None,
-                btime: None,
-                winc: None,
-                binc: None,
-                movetime: None,
+            Command::Go(Go {
                 depth: Some(12),
                 nodes: Some(100_000),
-                infinite: false,
-            }
+                ..Go::default()
+            })
         );
         assert_eq!(
             Command::parse("go infinite"),
-            Command::Go {
-                wtime: None,
-                btime: None,
-                winc: None,
-                binc: None,
-                movetime: None,
-                depth: None,
-                nodes: None,
+            Command::Go(Go {
                 infinite: true,
-            }
+                ..Go::default()
+            })
         );
     }
 }


### PR DESCRIPTION
## Summary

A quality-focused pass over the chess core and the tooling config. No behaviour changes — purely deduplication, modern idioms, and stricter lints. Verified against the full perft suite (including the shakmaty differential test), the incremental-hash invariant test, the UCI integration tests, and a self-play smoke game.

### Refactoring (`refactor:` commit)

- **`make_move`**: the Zobrist hash-update boilerplate (`self.hash ^= generated::get_piece_key(Piece { player, kind }, square)`) was repeated ~12 times across four sub-functions, each of which re-scanned the piece bitboards to find the mover. Introduced `toggle_piece`/`move_piece` helpers that keep the hash in sync, and determine the moving piece **once** via `Pieces::at`, then dispatch. Shorter and does less work per move (the old code ran every move through all four sub-functions).
- **Piece ↔ char**: replaced the two 12-arm `char`↔`Piece` matches with a single source of truth, `PieceKind::to_char`/`from_char`; `Piece` now derives `Copy`/`Clone`/`Eq`.
- **Castling generation**: encapsulated the static castle geometry in a `const Castle` table and iterate over it, deleting the 9-argument `try_castle` helper and its parallel 9-tuple destructure.
- **UCI**: the `go` command now carries a `Go` parameter struct instead of an 8-field enum variant feeding an 8-argument `Engine::go`; extracted `Engine::limits`. Both "too many arguments" clippy smells are gone, and the parser tests shrank via `..Go::default()`.
- Completed the `Bitboard` operator set with `toggle` + `BitXorAssign`.

### Harness (`chore:` commit)

You mentioned the lint config hadn't been revisited in a while — I measured the churn of every commented-out lint and turned on the ones that are already clean:

- **rustc lints**: enabled `unreachable_pub`, `trivial_numeric_casts`, `unused_qualifications`, `unused_import_braces`, `unused_lifetimes`, `unused_extern_crates`, `macro_use_extern_crate`, `absolute_paths_not_starting_with_crate` (all +0 warnings today). Left `missing_docs` / `let_underscore_drop` / `unused_results` deferred with a note — they still fire on undocumented public API and the search stubs.
- **clippy groups**: enabled `correctness` (deny), plus `complexity` and `style` (warn), alongside the existing `perf`/`suspicious` denies. `pedantic` (+844), `nursery` (+26) and `cargo` stay off — dominated by literal-separator noise and transitive-dependency version reports, not real issues.
- **rustfmt**: adopted `style_edition = "2024"`.
- Fixed the one real `style` finding this surfaced (`match` → `?` in the FEN parser).

## Testing

- `cargo test`: 130 tests + doctests pass.
- `cargo test --release -- --ignored`: all 12 expensive perft / shakmaty-differential tests pass (re-run after the castling and make/move refactors).
- Self-play smoke game (120 plies, incl. castling) over real UCI — no crashes, legal throughout.
- `cargo +nightly fmt --check` clean; `cargo clippy --all-targets --all-features` clean of denied lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVrKvkMe4xDmkRAksacBzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVrKvkMe4xDmkRAksacBzk)_