### PR TITLE
Reuse the search tree across moves and bound it by Hash

### DIFF
--- a/src/chess/game.rs
+++ b/src/chess/game.rs
@@ -28,6 +28,7 @@ impl Observation for Position {}
 /// `Game` is the shared substrate for both the UCI engine (which searches from
 /// the current position) and self-play data generation (which drives a game to
 /// a terminal result through the [`Environment`] interface).
+#[derive(Clone)]
 pub struct Game {
     position: Position,
     /// Zobrist hashes of every position reached so far, including the current

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -18,18 +18,35 @@ use crate::chess::game::{self, Game};
 use crate::chess::position::Position;
 use crate::engine::uci::Command;
 use crate::environment::{Environment, Player};
-use crate::search::mcts;
+use crate::search::{Tree, mcts};
 
 mod time_manager;
 mod uci;
 
+/// The `position` a search ran from, identifying the tree it produced so that
+/// the tree can be reused when the game continues along the same line.
+#[derive(Clone, Default)]
+struct PositionSpec {
+    fen: Option<String>,
+    moves: Vec<String>,
+}
+
+/// A search tree kept for reuse, together with the position it is rooted at.
+struct Reusable {
+    spec: PositionSpec,
+    tree: Tree,
+}
+
 /// A search running in a background thread. The search can be stopped through
-/// the flag; joining the handle guarantees that `bestmove` has been printed.
+/// the flag; joining the handle yields the grown tree (for reuse) and
+/// guarantees that `bestmove` has been printed.
 struct SearchThread {
     stop: Arc<AtomicBool>,
-    handle: thread::JoinHandle<()>,
+    handle: thread::JoinHandle<Tree>,
     /// Whether the search would run forever unless stopped externally.
     infinite: bool,
+    /// The position the search ran from.
+    spec: PositionSpec,
 }
 
 /// The Engine connects everything together and handles commands sent by UCI
@@ -38,13 +55,17 @@ struct SearchThread {
 pub struct Engine<R: BufRead, W: Write + Send + 'static> {
     /// The game the next search will start from.
     game: Game,
+    /// The `position` command that produced [`Self::game`], used to reuse the
+    /// search tree when the game continues along the same line.
+    spec: PositionSpec,
     debug: bool,
-    /// Requested transposition table size in MB. Stored for the time when the
-    /// search gets a transposition table.
+    /// Search tree size budget in MB (the UCI `Hash` option).
     hash_size_mb: usize,
     /// Number of search threads. Only single-threaded search is implemented so
     /// far.
     threads: usize,
+    /// Tree kept from the previous search for reuse.
+    reusable: Option<Reusable>,
     /// UCI commands will be read from this stream.
     input: R,
     /// Responses to UCI commands will be written to this stream. Shared with
@@ -60,9 +81,11 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
     pub fn new(input: R, out: W) -> Self {
         Self {
             game: Game::new(Position::starting()),
+            spec: PositionSpec::default(),
             debug: false,
             hash_size_mb: 16,
             threads: 1,
+            reusable: None,
             input,
             out: Arc::new(Mutex::new(out)),
             search: None,
@@ -220,14 +243,17 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
     fn new_game(&mut self) {
         self.stop_search();
         self.game = self.fresh_game(Position::starting());
+        self.spec = PositionSpec::default();
+        // A new game invalidates the tree from the previous one.
+        self.reusable = None;
     }
 
     /// Changes the position of the board to the one specified in the command.
     /// Each move is checked to be legal in the position it is applied to.
     fn set_position(&mut self, fen: Option<String>, moves: &[String]) -> anyhow::Result<()> {
         self.stop_search();
-        let root = match fen {
-            Some(fen) => Position::from_fen(&fen)?,
+        let root = match &fen {
+            Some(fen) => Position::from_fen(fen)?,
             None => Position::starting(),
         };
         let mut game = self.fresh_game(root);
@@ -240,6 +266,10 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
             game.apply(&next_move);
         }
         self.game = game;
+        self.spec = PositionSpec {
+            fen,
+            moves: moves.to_vec(),
+        };
         Ok(())
     }
 
@@ -275,45 +305,64 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
     }
 
     /// Starts the search in a background thread. The thread reports progress
-    /// through `info` lines and always finishes by printing `bestmove`.
+    /// through `info` lines, returns the grown tree for reuse, and always
+    /// finishes by printing `bestmove`.
     fn go(&mut self, go: &uci::Go) {
         self.stop_search();
 
         let limits = self.limits(go);
         let infinite = limits.infinite;
+        let tree = self.reuse_tree();
+        let node_budget = mcts::node_budget(self.hash_size_mb);
         let stop = Arc::new(AtomicBool::new(false));
-        let position = self.game.position().clone();
-        let history = self.game.history().to_vec();
-        let tablebase = self.game.tablebase();
+        let game = self.game.clone();
         let out = Arc::clone(&self.out);
         let search_stop = Arc::clone(&stop);
 
         let handle = thread::spawn(move || {
-            let result = mcts::search(
-                &position,
-                &history,
-                tablebase.as_deref(),
-                &limits,
-                &search_stop,
-                |info| {
-                    let mut out = out.lock().expect("output lock poisoned");
-                    let _ = writeln!(out, "{info}");
-                    let _ = out.flush();
-                },
-            );
+            let result = mcts::search(&game, tree, node_budget, &limits, &search_stop, |info| {
+                let mut out = out.lock().expect("output lock poisoned");
+                let _ = writeln!(out, "{info}");
+                let _ = out.flush();
+            });
             let best_move = result
                 .best_move
                 .map_or_else(|| "(none)".to_string(), |best_move| best_move.to_string());
-            let mut out = out.lock().expect("output lock poisoned");
-            let _ = writeln!(out, "bestmove {best_move}");
-            let _ = out.flush();
+            {
+                let mut out = out.lock().expect("output lock poisoned");
+                let _ = writeln!(out, "bestmove {best_move}");
+                let _ = out.flush();
+            }
+            result.tree
         });
 
         self.search = Some(SearchThread {
             stop,
             handle,
             infinite,
+            spec: self.spec.clone(),
         });
+    }
+
+    /// Returns the tree to seed the next search: the previous search's subtree
+    /// re-rooted at the current position when the game continued along the same
+    /// line, otherwise a fresh tree.
+    fn reuse_tree(&mut self) -> Tree {
+        let Some(reusable) = self.reusable.take() else {
+            return Tree::new();
+        };
+        if reusable.spec.fen == self.spec.fen && self.spec.moves.starts_with(&reusable.spec.moves) {
+            let played: Option<Vec<Move>> = self.spec.moves[reusable.spec.moves.len()..]
+                .iter()
+                .map(|uci| Move::from_uci(uci).ok())
+                .collect();
+            if let Some(played) = played
+                && let Some(tree) = reusable.tree.rerooted(&played)
+            {
+                return tree;
+            }
+        }
+        Tree::new()
     }
 
     /// Stops the running search (if any) and waits for it to print `bestmove`.
@@ -321,16 +370,21 @@ impl<R: BufRead, W: Write + Send + 'static> Engine<R, W> {
         self.finish_search(true);
     }
 
-    /// Waits for the running search (if any) to print `bestmove`. When `force`
-    /// is set, the search is interrupted; otherwise it runs until its own
-    /// limits expire (infinite searches are interrupted regardless, as they
-    /// have no limits to expire).
+    /// Waits for the running search (if any) to print `bestmove`, keeping its
+    /// tree for reuse. When `force` is set, the search is interrupted;
+    /// otherwise it runs until its own limits expire (infinite searches are
+    /// interrupted regardless, as they have no limits to expire).
     fn finish_search(&mut self, force: bool) {
         if let Some(search) = self.search.take() {
             if force || search.infinite {
                 search.stop.store(true, Ordering::Relaxed);
             }
-            let _ = search.handle.join();
+            if let Ok(tree) = search.handle.join() {
+                self.reusable = Some(Reusable {
+                    spec: search.spec,
+                    tree,
+                });
+            }
         }
     }
 
@@ -413,13 +467,20 @@ pub fn openbench() {
     let start = Instant::now();
     let mut total_nodes = 0;
     for fen in POSITIONS {
-        let position = Position::from_fen(fen).expect("bench positions are valid");
+        let game = Game::new(Position::from_fen(fen).expect("bench positions are valid"));
         let limits = mcts::Limits {
             nodes: Some(NODES_PER_POSITION),
             ..mcts::Limits::default()
         };
         let stop = AtomicBool::new(false);
-        let result = mcts::search(&position, &[position.hash()], None, &limits, &stop, |_| {});
+        let result = mcts::search(
+            &game,
+            Tree::new(),
+            mcts::node_budget(16),
+            &limits,
+            &stop,
+            |_| {},
+        );
         total_nodes += result.nodes;
         println!(
             "info string bench bestmove {} for {fen}",

--- a/src/search/mcts.rs
+++ b/src/search/mcts.rs
@@ -13,6 +13,7 @@
 //!
 //! [Monte Carlo Tree Search]: https://en.wikipedia.org/wiki/Monte_Carlo_tree_search
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
@@ -20,9 +21,9 @@ use shakmaty::Chess;
 use shakmaty_syzygy::Tablebase;
 
 use super::policy;
-use super::tree::{NodeId, ROOT_ID, Tree};
+use super::tree::{Node, NodeId, ROOT_ID, Tree};
 use crate::chess::core::Move;
-use crate::chess::game;
+use crate::chess::game::{self, Game};
 use crate::chess::position::Position;
 use crate::chess::zobrist::Key;
 use crate::environment::GameResult;
@@ -38,6 +39,15 @@ const CHECK_INTERVAL: u64 = 128;
 /// Maximum length of the principal variation to report.
 const MAX_PV_LENGTH: usize = 16;
 
+/// Converts a Hash option value (in MB) into a search tree node budget. The
+/// per-node estimate accounts for a [`Node`] and the small heap-allocated child
+/// list it typically owns.
+#[must_use]
+pub fn node_budget(hash_mb: usize) -> usize {
+    const BYTES_PER_NODE: usize = size_of::<Node>() + 32;
+    (hash_mb * 1_000_000 / BYTES_PER_NODE).max(1)
+}
+
 /// Limits controlling when the search stops. Multiple limits can be active at
 /// once: the search stops as soon as any of them is reached. Regardless of the
 /// limits, the search can always be stopped externally through the stop flag.
@@ -52,38 +62,42 @@ pub struct Limits {
 }
 
 /// Final result of a search.
-#[derive(Debug, Clone)]
 pub struct SearchResult {
     /// The move the engine considers best. `None` if the root position has no
     /// legal moves.
     pub best_move: Option<Move>,
     /// Number of search iterations performed.
     pub nodes: u64,
+    /// The search tree, returned so its statistics can seed a later search.
+    pub(crate) tree: Tree,
 }
 
-/// Searches the position and returns the best move.
+/// Searches the game's current position and returns the best move along with
+/// the (grown) search tree.
 ///
-/// `history` holds the Zobrist hashes of all positions of the game so far
-/// (including the root); it is used to score repetitions as draws. `tablebase`,
-/// when present, adjudicates positions with few enough pieces exactly.
+/// `tree` seeds the search: pass [`Tree::new`] for a fresh search or a
+/// [`Tree::rerooted`] subtree to reuse earlier statistics. `node_budget` caps
+/// the tree size to bound memory (see [`node_budget`]).
 ///
 /// `on_info` is called with UCI `info` lines as the search progresses.
-pub fn search(
-    root: &Position,
-    history: &[Key],
-    tablebase: Option<&Tablebase<Chess>>,
+pub(crate) fn search(
+    game: &Game,
+    tree: Tree,
+    node_budget: usize,
     limits: &Limits,
     stop: &AtomicBool,
     mut on_info: impl FnMut(&str),
 ) -> SearchResult {
-    if root.generate_moves().is_empty() {
+    let root_moves = game.position().generate_moves();
+    if root_moves.is_empty() {
         return SearchResult {
             best_move: None,
             nodes: 0,
+            tree,
         };
     }
 
-    let mut searcher = Searcher::new(root, history, tablebase);
+    let mut searcher = Searcher::new(game, tree, node_budget, &root_moves);
     let start = Instant::now();
     let mut iterations = 0u64;
     let mut max_depth = 0usize;
@@ -105,6 +119,7 @@ pub fn search(
     SearchResult {
         best_move: Some(searcher.best_move()),
         nodes: iterations,
+        tree: searcher.tree,
     }
 }
 
@@ -123,24 +138,24 @@ fn limits_reached(limits: &Limits, iterations: u64, start: Instant) -> bool {
 struct Searcher<'a> {
     root: &'a Position,
     history: &'a [Key],
-    tablebase: Option<&'a Tablebase<Chess>>,
+    tablebase: Option<Arc<Tablebase<Chess>>>,
+    /// Maximum number of nodes the tree is allowed to grow to.
+    node_budget: usize,
     tree: Tree,
 }
 
 impl<'a> Searcher<'a> {
-    /// Creates a searcher with the root node already expanded. The caller
-    /// guarantees the root has at least one legal move.
-    fn new(
-        root: &'a Position,
-        history: &'a [Key],
-        tablebase: Option<&'a Tablebase<Chess>>,
-    ) -> Self {
-        let mut tree = Tree::new();
-        expand(&mut tree, ROOT_ID, &root.generate_moves());
+    /// Creates a searcher, expanding the root node if the seed tree left it
+    /// unexpanded. The caller guarantees the root has at least one legal move.
+    fn new(game: &'a Game, mut tree: Tree, node_budget: usize, root_moves: &[Move]) -> Self {
+        if !tree.node(ROOT_ID).expanded {
+            expand(&mut tree, ROOT_ID, root_moves);
+        }
         Self {
-            root,
-            history,
-            tablebase,
+            root: game.position(),
+            history: game.history(),
+            tablebase: game.tablebase(),
+            node_budget,
             tree,
         }
     }
@@ -202,13 +217,17 @@ impl<'a> Searcher<'a> {
             return self.mark_terminal(node_id, 0.0);
         }
 
-        if let Some(tablebase) = self.tablebase
+        if let Some(tablebase) = &self.tablebase
             && let Some(result) = game::probe_tablebase(tablebase, position)
         {
             return self.mark_terminal(node_id, value_from_result(result));
         }
 
-        expand(&mut self.tree, node_id, &moves);
+        // Stop growing the tree once it reaches the memory budget; the leaf is
+        // still evaluated, it just is not expanded.
+        if self.tree.len() < self.node_budget {
+            expand(&mut self.tree, node_id, &moves);
+        }
         value_from_centipawns(evaluation::evaluate(position))
     }
 
@@ -350,12 +369,15 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+    use crate::environment::Environment;
+
+    fn search_game(game: &Game, limits: &Limits) -> SearchResult {
+        let stop = AtomicBool::new(false);
+        search(game, Tree::new(), usize::MAX, limits, &stop, |_| {})
+    }
 
     fn run(fen: &str, limits: &Limits) -> SearchResult {
-        let position = Position::from_fen(fen).unwrap();
-        let history = vec![position.hash()];
-        let stop = AtomicBool::new(false);
-        search(&position, &history, None, limits, &stop, |_| {})
+        search_game(&Game::new(Position::from_fen(fen).unwrap()), limits)
     }
 
     #[test]
@@ -396,15 +418,13 @@ mod tests {
 
     #[test]
     fn stops_immediately_when_stop_flag_is_set() {
-        let position = Position::starting();
-        let history = vec![position.hash()];
         let stop = AtomicBool::new(true);
         // Infinite search with a pre-set stop flag has to terminate and still
         // produce a legal move.
         let result = search(
-            &position,
-            &history,
-            None,
+            &Game::new(Position::starting()),
+            Tree::new(),
+            usize::MAX,
             &Limits {
                 infinite: true,
                 ..Limits::default()
@@ -430,29 +450,76 @@ mod tests {
 
     #[test]
     fn searches_with_tablebase() {
-        use crate::chess::game;
-
         const TABLEBASE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/syzygy");
-        let tablebase = game::load_tablebase(TABLEBASE_PATH.as_ref()).unwrap();
+        let tablebase = Arc::new(game::load_tablebase(TABLEBASE_PATH.as_ref()).unwrap());
 
         // KQvK is a tablebase win for White; the search probes the 3-piece
         // children and must still return a legal move.
         let position = Position::from_fen("4k3/8/8/8/4KQ2/8/8/8 w - - 0 1").unwrap();
-        let history = vec![position.hash()];
-        let stop = AtomicBool::new(false);
-        let result = search(
-            &position,
-            &history,
-            Some(&tablebase),
+        let mut game = Game::new(position.clone());
+        game.set_tablebase(Some(tablebase));
+        let result = search_game(
+            &game,
             &Limits {
                 nodes: Some(500),
+                ..Limits::default()
+            },
+        );
+        let best = result.best_move.expect("KQvK has legal moves");
+        assert!(position.generate_moves().contains(&best));
+    }
+
+    #[test]
+    fn reuses_tree_across_moves() {
+        // Search the starting position, then reuse the subtree under 1. e4 e5
+        // for the next search: the reused tree already carries visits, so the
+        // continuation search starts from a non-empty tree.
+        let mut game = Game::new(Position::starting());
+        let stop = AtomicBool::new(false);
+        let first = search(
+            &game,
+            Tree::new(),
+            usize::MAX,
+            &Limits {
+                nodes: Some(2000),
                 ..Limits::default()
             },
             &stop,
             |_| {},
         );
-        let best = result.best_move.expect("KQvK has legal moves");
-        assert!(position.generate_moves().contains(&best));
+
+        let line = [
+            Move::from_uci("e2e4").unwrap(),
+            Move::from_uci("e7e5").unwrap(),
+        ];
+        let reused = first
+            .tree
+            .rerooted(&line)
+            .expect("the 1. e4 e5 line was explored");
+        assert!(reused.len() > 1, "reused subtree should carry statistics");
+
+        for played in line {
+            game.apply(&played);
+        }
+        let second = search(
+            &game,
+            reused,
+            usize::MAX,
+            &Limits {
+                nodes: Some(100),
+                ..Limits::default()
+            },
+            &stop,
+            |_| {},
+        );
+        let best = second.best_move.expect("position has moves");
+        assert!(game.position().generate_moves().contains(&best));
+    }
+
+    #[test]
+    fn node_budget_scales_with_hash() {
+        assert!(node_budget(64) > node_budget(1));
+        assert!(node_budget(0) >= 1);
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -5,3 +5,5 @@
 pub mod mcts;
 mod policy;
 mod tree;
+
+pub(crate) use tree::Tree;

--- a/src/search/tree.rs
+++ b/src/search/tree.rs
@@ -7,6 +7,8 @@
 //! value $Q(s, a)$ is valued from the perspective of the player to move at the
 //! parent node.
 
+use std::collections::HashMap;
+
 use crate::chess::core::Move;
 
 /// Index of a node in the [`Tree`] arena.
@@ -15,6 +17,7 @@ pub(super) type NodeId = u32;
 /// Index of the root node: the tree always contains the root at index 0.
 pub(super) const ROOT_ID: NodeId = 0;
 
+#[derive(Clone)]
 pub(super) struct Node {
     /// The action that leads to this node. `None` only for the root.
     pub(super) action: Option<Move>,
@@ -60,16 +63,23 @@ impl Node {
     }
 }
 
-pub(super) struct Tree {
+/// The search tree, held between searches so that its statistics can be reused
+/// as the game continues (see [`Tree::rerooted`]).
+pub(crate) struct Tree {
     nodes: Vec<Node>,
 }
 
 impl Tree {
     /// Creates a tree containing only an unexpanded root node.
-    pub(super) fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             nodes: vec![Node::new(None, 1.0)],
         }
+    }
+
+    /// Number of nodes in the tree, used to bound its memory footprint.
+    pub(crate) fn len(&self) -> usize {
+        self.nodes.len()
     }
 
     pub(super) fn node(&self, id: NodeId) -> &Node {
@@ -86,5 +96,52 @@ impl Tree {
         self.nodes.push(Node::new(Some(action), prior));
         self.nodes[parent as usize].children.push(id);
         id
+    }
+
+    /// Returns the subtree reached by playing `moves` from the root, compacted
+    /// into a fresh arena, so the accumulated statistics can seed the next
+    /// search. Returns `None` if the line was never expanded in this tree.
+    pub(crate) fn rerooted(&self, moves: &[Move]) -> Option<Self> {
+        let mut root = ROOT_ID;
+        for played in moves {
+            root = *self
+                .node(root)
+                .children
+                .iter()
+                .find(|&&child| self.node(child).action == Some(*played))?;
+        }
+
+        // Breadth-first walk assigning new, contiguous ids to the reachable
+        // nodes, then copy them over with remapped children.
+        let mut order = vec![root];
+        let mut remap = HashMap::from([(root, ROOT_ID)]);
+        let mut scanned = 0;
+        while scanned < order.len() {
+            for &child in &self.node(order[scanned]).children {
+                let new_id = NodeId::try_from(order.len()).expect("subtree fits in u32");
+                remap.insert(child, new_id);
+                order.push(child);
+            }
+            scanned += 1;
+        }
+
+        let nodes = order
+            .iter()
+            .map(|&old| {
+                let mut node = self.node(old).clone();
+                node.children = node.children.iter().map(|child| remap[child]).collect();
+                // Terminal values can be repetition-dependent (they are computed
+                // against the search path and game history). The path context
+                // changes when re-rooting, so drop the cache and let the next
+                // visit re-derive it; position-only terminals (mate, 50-move)
+                // are re-derived cheaply.
+                node.terminal = None;
+                node
+            })
+            .collect();
+        let mut tree = Self { nodes };
+        // The new root has no incoming action.
+        tree.nodes[ROOT_ID as usize].action = None;
+        Some(tree)
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -106,6 +106,25 @@ fn openbench_output() {
 }
 
 #[test]
+fn uci_reuses_tree_across_continuing_searches() {
+    // Two searches on the same continuing game exercise the tree-reuse path in
+    // a single process; both must still produce a legal bestmove.
+    let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");
+
+    drop(
+        cmd.write_stdin(
+            "position startpos moves e2e4\ngo nodes 800\n\
+             position startpos moves e2e4 e7e5\ngo nodes 800\nquit\n",
+        )
+        .assert()
+        .success()
+        .stdout(
+            is_match(r"(?s)bestmove [a-h][1-8][a-h][1-8].*bestmove [a-h][1-8][a-h][1-8]").unwrap(),
+        ),
+    );
+}
+
+#[test]
 fn uci_loads_syzygy_tablebase() {
     let tablebase_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/syzygy");
     let mut cmd = assert_cmd::cargo_bin_cmd!("pabi");


### PR DESCRIPTION
## Summary

Second in the sequence (after #325). Makes the `Hash` option real and stops throwing away search work between moves.

Previously `Hash` was stored but unused, and every `go` rebuilt the MCTS tree from scratch — discarding the subtree under the move just played, which is still valid and already carries statistics.

### Changes

- **Tree reuse across moves.** The background search thread now returns its grown tree; the engine keeps it and, on the next `go`, re-roots it to the current position by replaying the moves added since the last search. `Tree::rerooted` compacts the reached subtree into a fresh arena (BFS re-indexing). A game continued along the same line reuses the accumulated visit statistics instead of starting cold; an unrelated position falls back to a fresh tree. Re-rooting **clears each node's `terminal` cache**, since terminal values can be repetition/path-dependent and the path context changes on re-root — they're re-derived cheaply on the next visit.
- **`Hash` bounds the tree.** `mcts::node_budget` converts the MB setting into a node budget; expansion stops once the tree reaches it (leaves are still evaluated). Prevents unbounded growth in long/infinite searches.
- **Search API cleanup.** `mcts::search` now takes a `&Game` (cloned into the thread) plus the seed tree and budget, instead of loose `position`/`history`/`tablebase` arguments; `Game` derives `Clone`.

### Testing

- 131 tests pass, incl. new unit tests for tree reuse (`rerooted` carries statistics; the continuation search returns a legal move) and node-budget scaling, plus a UCI integration test driving two continuing searches in one process.
- Manual: a full self-play game driven inside a single process (so reuse fires on every move) plays cleanly; tablebase endgame search still reports winning scores.
- `cargo clippy --all-targets --all-features` zero warnings; `cargo +nightly fmt --check` clean.

Move generation and `make_move` are untouched, so perft correctness is unaffected.

## Next in the sequence

`datagen` self-play (built on `Game`), a UCI-completeness pass, and the `transmute` safety cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVrKvkMe4xDmkRAksacBzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVrKvkMe4xDmkRAksacBzk)_